### PR TITLE
refactor to return (result, error), and implement pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ func main() {
                 Title: "fix bug. #9999",
                 Close_source_branch: true,
         }
-        res := c.Repositories.PullRequests.Create(opt)
+        res, err := c.Repositories.PullRequests.Create(opt)
+        if err != nil {
+                panic(err)
+        }
 
         fmt.Println(res) // receive the data as json format
 }

--- a/bitbucket.go
+++ b/bitbucket.go
@@ -11,83 +11,83 @@ func SetApiBaseURL(url string) {
 }
 
 type users interface {
-	Get(username string) interface{}
-	Followers(username string) interface{}
-	Following(username string) interface{}
-	Repositories(username string) interface{}
+	Get(username string) (interface{}, error)
+	Followers(username string) (interface{}, error)
+	Following(username string) (interface{}, error)
+	Repositories(username string) (interface{}, error)
 }
 
 type user interface {
-	Profile() interface{}
-	Emails() interface{}
+	Profile() (interface{}, error)
+	Emails() (interface{}, error)
 }
 
 type pullrequests interface {
-	Create(opt PullRequestsOptions) interface{}
-	Update(opt PullRequestsOptions) interface{}
-	List(opt PullRequestsOptions) interface{}
-	Get(opt PullRequestsOptions) interface{}
-	Activities(opt PullRequestsOptions) interface{}
-	Activity(opt PullRequestsOptions) interface{}
-	Commits(opt PullRequestsOptions) interface{}
-	Patch(opt PullRequestsOptions) interface{}
-	Diff(opt PullRequestsOptions) interface{}
-	Merge(opt PullRequestsOptions) interface{}
-	Decline(opt PullRequestsOptions) interface{}
+	Create(opt PullRequestsOptions) (interface{}, error)
+	Update(opt PullRequestsOptions) (interface{}, error)
+	List(opt PullRequestsOptions) (interface{}, error)
+	Get(opt PullRequestsOptions) (interface{}, error)
+	Activities(opt PullRequestsOptions) (interface{}, error)
+	Activity(opt PullRequestsOptions) (interface{}, error)
+	Commits(opt PullRequestsOptions) (interface{}, error)
+	Patch(opt PullRequestsOptions) (interface{}, error)
+	Diff(opt PullRequestsOptions) (interface{}, error)
+	Merge(opt PullRequestsOptions) (interface{}, error)
+	Decline(opt PullRequestsOptions) (interface{}, error)
 }
 
 type repository interface {
-	Get(opt RepositoryOptions) (error, Repository)
-	Create(opt RepositoryOptions) (error, Repository)
-	Delete(opt RepositoryOptions) interface{}
-	ListWatchers(opt RepositoryOptions) interface{}
-	ListForks(opt RepositoryOptions) interface{}
+	Get(opt RepositoryOptions) (*Repository, error)
+	Create(opt RepositoryOptions) (*Repository, error)
+	Delete(opt RepositoryOptions) (interface{}, error)
+	ListWatchers(opt RepositoryOptions) (interface{}, error)
+	ListForks(opt RepositoryOptions) (interface{}, error)
 }
 
 type repositories interface {
-	ListForAccount(opt RepositoriesOptions) interface{}
-	ListForTeam(opt RepositoriesOptions) interface{}
-	ListPublic() interface{}
+	ListForAccount(opt RepositoriesOptions) (interface{}, error)
+	ListForTeam(opt RepositoriesOptions) (interface{}, error)
+	ListPublic() (interface{}, error)
 }
 
 type commits interface {
-	GetCommits(opt CommitsOptions) interface{}
-	GetCommit(opt CommitsOptions) interface{}
-	GetCommitComments(opt CommitsOptions) interface{}
-	GetCommitComment(opt CommitsOptions) interface{}
-	GetCommitStatus(opt CommitsOptions) interface{}
-	GiveApprove(opt CommitsOptions) interface{}
-	RemoveApprove(opt CommitsOptions) interface{}
+	GetCommits(opt CommitsOptions) (interface{}, error)
+	GetCommit(opt CommitsOptions) (interface{}, error)
+	GetCommitComments(opt CommitsOptions) (interface{}, error)
+	GetCommitComment(opt CommitsOptions) (interface{}, error)
+	GetCommitStatus(opt CommitsOptions) (interface{}, error)
+	GiveApprove(opt CommitsOptions) (interface{}, error)
+	RemoveApprove(opt CommitsOptions) (interface{}, error)
 }
 
 type branchrestrictions interface {
-	Gets(opt BranchRestrictionsOptions) interface{}
-	Get(opt BranchRestrictionsOptions) interface{}
-	Create(opt BranchRestrictionsOptions) interface{}
-	Update(opt BranchRestrictionsOptions) interface{}
-	Delete(opt BranchRestrictionsOptions) interface{}
+	Gets(opt BranchRestrictionsOptions) (interface{}, error)
+	Get(opt BranchRestrictionsOptions) (interface{}, error)
+	Create(opt BranchRestrictionsOptions) (interface{}, error)
+	Update(opt BranchRestrictionsOptions) (interface{}, error)
+	Delete(opt BranchRestrictionsOptions) (interface{}, error)
 }
 
 type diff interface {
-	GetDiff(opt DiffOptions) interface{}
-	GetPatch(opt DiffOptions) interface{}
+	GetDiff(opt DiffOptions) (interface{}, error)
+	GetPatch(opt DiffOptions) (interface{}, error)
 }
 
 type webhooks interface {
-	Gets(opt WebhooksOptions) interface{}
-	Get(opt WebhooksOptions) interface{}
-	Create(opt WebhooksOptions) interface{}
-	Update(opt WebhooksOptions) interface{}
-	Delete(opt WebhooksOptions) interface{}
+	Gets(opt WebhooksOptions) (interface{}, error)
+	Get(opt WebhooksOptions) (interface{}, error)
+	Create(opt WebhooksOptions) (interface{}, error)
+	Update(opt WebhooksOptions) (interface{}, error)
+	Delete(opt WebhooksOptions) (interface{}, error)
 }
 
 type teams interface {
-	List(role string) interface{} // [WIP?] role=[admin|contributor|member]
-	Profile(teamname string) interface{}
-	Members(teamname string) interface{}
-	Followers(teamname string) interface{}
-	Following(teamname string) interface{}
-	Repositories(teamname string) interface{}
+	List(role string) (interface{}, error) // [WIP?] role=[admin|contributor|member]
+	Profile(teamname string) (interface{}, error)
+	Members(teamname string) (interface{}, error)
+	Followers(teamname string) (interface{}, error)
+	Following(teamname string) (interface{}, error)
+	Repositories(teamname string) (interface{}, error)
 }
 
 type RepositoriesOptions struct {

--- a/bitbucket.go
+++ b/bitbucket.go
@@ -6,8 +6,8 @@ func GetApiBaseURL() string {
 	return apiBaseURL
 }
 
-func SetApiBaseURL(url string) {
-	apiBaseURL = url
+func SetApiBaseURL(urlStr string) {
+	apiBaseURL = urlStr
 }
 
 type users interface {

--- a/branchrestrictions.go
+++ b/branchrestrictions.go
@@ -12,30 +12,30 @@ type BranchRestrictions struct {
 }
 
 func (b *BranchRestrictions) Gets(bo *BranchRestrictionsOptions) (interface{}, error) {
-	url := b.c.requestUrl("/repositories/%s/%s/branch-restrictions", bo.Owner, bo.Repo_slug)
-	return b.c.execute("GET", url, "")
+	urlStr := b.c.requestUrl("/repositories/%s/%s/branch-restrictions", bo.Owner, bo.Repo_slug)
+	return b.c.execute("GET", urlStr, "")
 }
 
 func (b *BranchRestrictions) Create(bo *BranchRestrictionsOptions) (interface{}, error) {
 	data := b.buildBranchRestrictionsBody(bo)
-	url := b.c.requestUrl("/repositories/%s/%s/branch-restrictions", bo.Owner, bo.Repo_slug)
-	return b.c.execute("POST", url, data)
+	urlStr := b.c.requestUrl("/repositories/%s/%s/branch-restrictions", bo.Owner, bo.Repo_slug)
+	return b.c.execute("POST", urlStr, data)
 }
 
 func (b *BranchRestrictions) Get(bo *BranchRestrictionsOptions) (interface{}, error) {
-	url := b.c.requestUrl("/repositories/%s/%s/branch-restrictions/%s", bo.Owner, bo.Repo_slug, bo.Id)
-	return b.c.execute("GET", url, "")
+	urlStr := b.c.requestUrl("/repositories/%s/%s/branch-restrictions/%s", bo.Owner, bo.Repo_slug, bo.Id)
+	return b.c.execute("GET", urlStr, "")
 }
 
 func (b *BranchRestrictions) Update(bo *BranchRestrictionsOptions) (interface{}, error) {
 	data := b.buildBranchRestrictionsBody(bo)
-	url := b.c.requestUrl("/repositories/%s/%s/branch-restrictions/%s", bo.Owner, bo.Repo_slug, bo.Id)
-	return b.c.execute("PUT", url, data)
+	urlStr := b.c.requestUrl("/repositories/%s/%s/branch-restrictions/%s", bo.Owner, bo.Repo_slug, bo.Id)
+	return b.c.execute("PUT", urlStr, data)
 }
 
 func (b *BranchRestrictions) Delete(bo *BranchRestrictionsOptions) (interface{}, error) {
-	url := b.c.requestUrl("/repositories/%s/%s/branch-restrictions/%s", bo.Owner, bo.Repo_slug, bo.Id)
-	return b.c.execute("DELETE", url, "")
+	urlStr := b.c.requestUrl("/repositories/%s/%s/branch-restrictions/%s", bo.Owner, bo.Repo_slug, bo.Id)
+	return b.c.execute("DELETE", urlStr, "")
 }
 
 type branchRestrictionsBody struct {

--- a/branchrestrictions.go
+++ b/branchrestrictions.go
@@ -2,37 +2,38 @@ package bitbucket
 
 import (
 	"encoding/json"
-	"github.com/k0kubun/pp"
 	"os"
+
+	"github.com/k0kubun/pp"
 )
 
 type BranchRestrictions struct {
 	c *Client
 }
 
-func (b *BranchRestrictions) Gets(bo *BranchRestrictionsOptions) interface{} {
+func (b *BranchRestrictions) Gets(bo *BranchRestrictionsOptions) (interface{}, error) {
 	url := b.c.requestUrl("/repositories/%s/%s/branch-restrictions", bo.Owner, bo.Repo_slug)
 	return b.c.execute("GET", url, "")
 }
 
-func (b *BranchRestrictions) Create(bo *BranchRestrictionsOptions) interface{} {
+func (b *BranchRestrictions) Create(bo *BranchRestrictionsOptions) (interface{}, error) {
 	data := b.buildBranchRestrictionsBody(bo)
 	url := b.c.requestUrl("/repositories/%s/%s/branch-restrictions", bo.Owner, bo.Repo_slug)
 	return b.c.execute("POST", url, data)
 }
 
-func (b *BranchRestrictions) Get(bo *BranchRestrictionsOptions) interface{} {
+func (b *BranchRestrictions) Get(bo *BranchRestrictionsOptions) (interface{}, error) {
 	url := b.c.requestUrl("/repositories/%s/%s/branch-restrictions/%s", bo.Owner, bo.Repo_slug, bo.Id)
 	return b.c.execute("GET", url, "")
 }
 
-func (b *BranchRestrictions) Update(bo *BranchRestrictionsOptions) interface{} {
+func (b *BranchRestrictions) Update(bo *BranchRestrictionsOptions) (interface{}, error) {
 	data := b.buildBranchRestrictionsBody(bo)
 	url := b.c.requestUrl("/repositories/%s/%s/branch-restrictions/%s", bo.Owner, bo.Repo_slug, bo.Id)
 	return b.c.execute("PUT", url, data)
 }
 
-func (b *BranchRestrictions) Delete(bo *BranchRestrictionsOptions) interface{} {
+func (b *BranchRestrictions) Delete(bo *BranchRestrictionsOptions) (interface{}, error) {
 	url := b.c.requestUrl("/repositories/%s/%s/branch-restrictions/%s", bo.Owner, bo.Repo_slug, bo.Id)
 	return b.c.execute("DELETE", url, "")
 }

--- a/client.go
+++ b/client.go
@@ -90,16 +90,28 @@ func (c *Client) execute(method, url, text string) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
 
-	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf(resp.Status)
+	}
 
-	buf, err := ioutil.ReadAll(resp.Body)
+	if resp.Body == nil {
+		return nil, fmt.Errorf("response body is nil")
+	}
+
+	resBodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
 
 	var result interface{}
-	json.Unmarshal(buf, &result)
+	err = json.Unmarshal(resBodyBytes, &result)
+	if err != nil {
+		return nil, err
+	}
 
 	return result, nil
 }

--- a/client.go
+++ b/client.go
@@ -6,7 +6,7 @@ import (
 
 	"io/ioutil"
 	"net/http"
-	urls "net/url"
+	"net/url"
 	"strconv"
 	"strings"
 )
@@ -54,24 +54,24 @@ func injectClient(a *auth) *Client {
 	return c
 }
 
-func (c *Client) execute(method, url, text string) (interface{}, error) {
+func (c *Client) execute(method string, urlStr string, text string) (interface{}, error) {
 	// Use pagination if changed from default value
 	const DEC_RADIX = 10
-	if strings.Contains(url, "/repositories/") {
+	if strings.Contains(urlStr, "/repositories/") {
 		if c.Pagelen != DEFAULT_PAGE_LENGHT {
-			urlObj, err := urls.Parse(url)
+			urlObj, err := url.Parse(urlStr)
 			if err != nil {
 				return nil, err
 			}
 			q := urlObj.Query()
 			q.Set("pagelen", strconv.FormatUint(c.Pagelen, DEC_RADIX))
 			urlObj.RawQuery = q.Encode()
-			url = urlObj.String()
+			urlStr = urlObj.String()
 		}
 	}
 
 	body := strings.NewReader(text)
-	req, err := http.NewRequest(method, url, body)
+	req, err := http.NewRequest(method, urlStr, body)
 	if text != "" {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/client.go
+++ b/client.go
@@ -54,7 +54,7 @@ func injectClient(a *auth) *Client {
 	return c
 }
 
-func (c *Client) execute(method, url, text string) interface{} {
+func (c *Client) execute(method, url, text string) (interface{}, error) {
 
 	// Use pagination if changed from default value
 	const DEC_RADIX = 10
@@ -62,7 +62,7 @@ func (c *Client) execute(method, url, text string) interface{} {
 		if c.Pagelen != DEFAULT_PAGE_LENGHT {
 			urlObj, err := urls.Parse(url)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			q := urlObj.Query()
 			q.Set("pagelen", strconv.FormatUint(c.Pagelen, DEC_RADIX))
@@ -78,7 +78,7 @@ func (c *Client) execute(method, url, text string) interface{} {
 	}
 
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if c.Auth.user != "" && c.Auth.password != "" {
@@ -88,20 +88,20 @@ func (c *Client) execute(method, url, text string) interface{} {
 	client := new(http.Client)
 	resp, err := client.Do(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	defer resp.Body.Close()
 
 	buf, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var result interface{}
 	json.Unmarshal(buf, &result)
 
-	return result
+	return result, nil
 }
 
 func (c *Client) requestUrl(template string, args ...interface{}) string {

--- a/commits.go
+++ b/commits.go
@@ -7,44 +7,44 @@ type Commits struct {
 }
 
 func (cm *Commits) GetCommits(cmo *CommitsOptions) (interface{}, error) {
-	url := cm.c.requestUrl("/repositories/%s/%s/commits/%s", cmo.Owner, cmo.Repo_slug, cmo.Branchortag)
-	url += cm.buildCommitsQuery(cmo.Include, cmo.Exclude)
-	return cm.c.execute("GET", url, "")
+	urlStr := cm.c.requestUrl("/repositories/%s/%s/commits/%s", cmo.Owner, cmo.Repo_slug, cmo.Branchortag)
+	urlStr += cm.buildCommitsQuery(cmo.Include, cmo.Exclude)
+	return cm.c.execute("GET", urlStr, "")
 }
 
 func (cm *Commits) GetCommit(cmo *CommitsOptions) (interface{}, error) {
-	url := cm.c.requestUrl("/repositories/%s/%s/commit/%s", cmo.Owner, cmo.Repo_slug, cmo.Revision)
-	return cm.c.execute("GET", url, "")
+	urlStr := cm.c.requestUrl("/repositories/%s/%s/commit/%s", cmo.Owner, cmo.Repo_slug, cmo.Revision)
+	return cm.c.execute("GET", urlStr, "")
 }
 
 func (cm *Commits) GetCommitComments(cmo *CommitsOptions) (interface{}, error) {
-	url := cm.c.requestUrl("/repositories/%s/%s/commit/%s/comments", cmo.Owner, cmo.Repo_slug, cmo.Revision)
-	return cm.c.execute("DELETE", url, "")
+	urlStr := cm.c.requestUrl("/repositories/%s/%s/commit/%s/comments", cmo.Owner, cmo.Repo_slug, cmo.Revision)
+	return cm.c.execute("DELETE", urlStr, "")
 }
 
 func (cm *Commits) GetCommitComment(cmo *CommitsOptions) (interface{}, error) {
-	url := cm.c.requestUrl("/repositories/%s/%s/commit/%s/comments/%s", cmo.Owner, cmo.Repo_slug, cmo.Revision, cmo.Comment_id)
-	return cm.c.execute("GET", url, "")
+	urlStr := cm.c.requestUrl("/repositories/%s/%s/commit/%s/comments/%s", cmo.Owner, cmo.Repo_slug, cmo.Revision, cmo.Comment_id)
+	return cm.c.execute("GET", urlStr, "")
 }
 
 func (cm *Commits) GetCommitStatuses(cmo *CommitsOptions) (interface{}, error) {
-	url := cm.c.requestUrl("/repositories/%s/%s/commit/%s/statuses", cmo.Owner, cmo.Repo_slug, cmo.Revision)
-	return cm.c.execute("GET", url, "")
+	urlStr := cm.c.requestUrl("/repositories/%s/%s/commit/%s/statuses", cmo.Owner, cmo.Repo_slug, cmo.Revision)
+	return cm.c.execute("GET", urlStr, "")
 }
 
 func (cm *Commits) GetCommitStatus(cmo *CommitsOptions, commitStatusKey string) (interface{}, error) {
-	url := cm.c.requestUrl("/repositories/%s/%s/commit/%s/statuses/build/%s", cmo.Owner, cmo.Repo_slug, cmo.Revision, commitStatusKey)
-	return cm.c.execute("GET", url, "")
+	urlStr := cm.c.requestUrl("/repositories/%s/%s/commit/%s/statuses/build/%s", cmo.Owner, cmo.Repo_slug, cmo.Revision, commitStatusKey)
+	return cm.c.execute("GET", urlStr, "")
 }
 
 func (cm *Commits) GiveApprove(cmo *CommitsOptions) (interface{}, error) {
-	url := cm.c.requestUrl("/repositories/%s/%s/commit/%s/approve", cmo.Owner, cmo.Repo_slug, cmo.Revision)
-	return cm.c.execute("POST", url, "")
+	urlStr := cm.c.requestUrl("/repositories/%s/%s/commit/%s/approve", cmo.Owner, cmo.Repo_slug, cmo.Revision)
+	return cm.c.execute("POST", urlStr, "")
 }
 
 func (cm *Commits) RemoveApprove(cmo *CommitsOptions) (interface{}, error) {
-	url := cm.c.requestUrl("/repositories/%s/%s/commit/%s/approve", cmo.Owner, cmo.Repo_slug, cmo.Revision)
-	return cm.c.execute("DELETE", url, "")
+	urlStr := cm.c.requestUrl("/repositories/%s/%s/commit/%s/approve", cmo.Owner, cmo.Repo_slug, cmo.Revision)
+	return cm.c.execute("DELETE", urlStr, "")
 }
 
 func (cm *Commits) buildCommitsQuery(include, exclude string) string {

--- a/commits.go
+++ b/commits.go
@@ -6,43 +6,43 @@ type Commits struct {
 	c *Client
 }
 
-func (cm *Commits) GetCommits(cmo *CommitsOptions) interface{} {
+func (cm *Commits) GetCommits(cmo *CommitsOptions) (interface{}, error) {
 	url := cm.c.requestUrl("/repositories/%s/%s/commits/%s", cmo.Owner, cmo.Repo_slug, cmo.Branchortag)
 	url += cm.buildCommitsQuery(cmo.Include, cmo.Exclude)
 	return cm.c.execute("GET", url, "")
 }
 
-func (cm *Commits) GetCommit(cmo *CommitsOptions) interface{} {
+func (cm *Commits) GetCommit(cmo *CommitsOptions) (interface{}, error) {
 	url := cm.c.requestUrl("/repositories/%s/%s/commit/%s", cmo.Owner, cmo.Repo_slug, cmo.Revision)
 	return cm.c.execute("GET", url, "")
 }
 
-func (cm *Commits) GetCommitComments(cmo *CommitsOptions) interface{} {
+func (cm *Commits) GetCommitComments(cmo *CommitsOptions) (interface{}, error) {
 	url := cm.c.requestUrl("/repositories/%s/%s/commit/%s/comments", cmo.Owner, cmo.Repo_slug, cmo.Revision)
 	return cm.c.execute("DELETE", url, "")
 }
 
-func (cm *Commits) GetCommitComment(cmo *CommitsOptions) interface{} {
+func (cm *Commits) GetCommitComment(cmo *CommitsOptions) (interface{}, error) {
 	url := cm.c.requestUrl("/repositories/%s/%s/commit/%s/comments/%s", cmo.Owner, cmo.Repo_slug, cmo.Revision, cmo.Comment_id)
 	return cm.c.execute("GET", url, "")
 }
 
-func (cm *Commits) GetCommitStatuses(cmo *CommitsOptions) interface{} {
+func (cm *Commits) GetCommitStatuses(cmo *CommitsOptions) (interface{}, error) {
 	url := cm.c.requestUrl("/repositories/%s/%s/commit/%s/statuses", cmo.Owner, cmo.Repo_slug, cmo.Revision)
 	return cm.c.execute("GET", url, "")
 }
 
-func (cm *Commits) GetCommitStatus(cmo *CommitsOptions, commitStatusKey string) interface{} {
+func (cm *Commits) GetCommitStatus(cmo *CommitsOptions, commitStatusKey string) (interface{}, error) {
 	url := cm.c.requestUrl("/repositories/%s/%s/commit/%s/statuses/build/%s", cmo.Owner, cmo.Repo_slug, cmo.Revision, commitStatusKey)
 	return cm.c.execute("GET", url, "")
 }
 
-func (cm *Commits) GiveApprove(cmo *CommitsOptions) interface{} {
+func (cm *Commits) GiveApprove(cmo *CommitsOptions) (interface{}, error) {
 	url := cm.c.requestUrl("/repositories/%s/%s/commit/%s/approve", cmo.Owner, cmo.Repo_slug, cmo.Revision)
 	return cm.c.execute("POST", url, "")
 }
 
-func (cm *Commits) RemoveApprove(cmo *CommitsOptions) interface{} {
+func (cm *Commits) RemoveApprove(cmo *CommitsOptions) (interface{}, error) {
 	url := cm.c.requestUrl("/repositories/%s/%s/commit/%s/approve", cmo.Owner, cmo.Repo_slug, cmo.Revision)
 	return cm.c.execute("DELETE", url, "")
 }

--- a/diff.go
+++ b/diff.go
@@ -5,11 +5,11 @@ type Diff struct {
 }
 
 func (d *Diff) GetDiff(do *DiffOptions) (interface{}, error) {
-	url := d.c.requestUrl("/repositories/%s/%s/diff/%s", do.Owner, do.Repo_slug, do.Spec)
-	return d.c.execute("GET", url, "")
+	urlStr := d.c.requestUrl("/repositories/%s/%s/diff/%s", do.Owner, do.Repo_slug, do.Spec)
+	return d.c.execute("GET", urlStr, "")
 }
 
 func (d *Diff) GetPatch(do *DiffOptions) (interface{}, error) {
-	url := d.c.requestUrl("/repositories/%s/%s/patch/%s", do.Owner, do.Repo_slug, do.Spec)
-	return d.c.execute("GET", url, "")
+	urlStr := d.c.requestUrl("/repositories/%s/%s/patch/%s", do.Owner, do.Repo_slug, do.Spec)
+	return d.c.execute("GET", urlStr, "")
 }

--- a/diff.go
+++ b/diff.go
@@ -4,12 +4,12 @@ type Diff struct {
 	c *Client
 }
 
-func (d *Diff) GetDiff(do *DiffOptions) interface{} {
+func (d *Diff) GetDiff(do *DiffOptions) (interface{}, error) {
 	url := d.c.requestUrl("/repositories/%s/%s/diff/%s", do.Owner, do.Repo_slug, do.Spec)
 	return d.c.execute("GET", url, "")
 }
 
-func (d *Diff) GetPatch(do *DiffOptions) interface{} {
+func (d *Diff) GetPatch(do *DiffOptions) (interface{}, error) {
 	url := d.c.requestUrl("/repositories/%s/%s/patch/%s", do.Owner, do.Repo_slug, do.Spec)
 	return d.c.execute("GET", url, "")
 }

--- a/pullrequests.go
+++ b/pullrequests.go
@@ -11,71 +11,71 @@ type PullRequests struct {
 	c *Client
 }
 
-func (p *PullRequests) Create(po *PullRequestsOptions) interface{} {
+func (p *PullRequests) Create(po *PullRequestsOptions) (interface{}, error) {
 	data := p.buildPullRequestBody(po)
 	url := p.c.requestUrl("/repositories/%s/%s/pullrequests/", po.Owner, po.Repo_slug)
 	return p.c.execute("POST", url, data)
 }
 
-func (p *PullRequests) Update(po *PullRequestsOptions) interface{} {
+func (p *PullRequests) Update(po *PullRequestsOptions) (interface{}, error) {
 	data := p.buildPullRequestBody(po)
 	url := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id
 	return p.c.execute("PUT", url, data)
 }
 
-func (p *PullRequests) Gets(po *PullRequestsOptions) interface{} {
+func (p *PullRequests) Gets(po *PullRequestsOptions) (interface{}, error) {
 	url := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/"
 	return p.c.execute("GET", url, "")
 }
 
-func (p *PullRequests) Get(po *PullRequestsOptions) interface{} {
+func (p *PullRequests) Get(po *PullRequestsOptions) (interface{}, error) {
 	url := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id
 	return p.c.execute("GET", url, "")
 }
 
-func (p *PullRequests) Activities(po *PullRequestsOptions) interface{} {
+func (p *PullRequests) Activities(po *PullRequestsOptions) (interface{}, error) {
 	url := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/activity"
 	return p.c.execute("GET", url, "")
 }
 
-func (p *PullRequests) Activity(po *PullRequestsOptions) interface{} {
+func (p *PullRequests) Activity(po *PullRequestsOptions) (interface{}, error) {
 	url := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id + "/activity"
 	return p.c.execute("GET", url, "")
 }
 
-func (p *PullRequests) Commits(po *PullRequestsOptions) interface{} {
+func (p *PullRequests) Commits(po *PullRequestsOptions) (interface{}, error) {
 	url := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id + "/commits"
 	return p.c.execute("GET", url, "")
 }
 
-func (p *PullRequests) Patch(po *PullRequestsOptions) interface{} {
+func (p *PullRequests) Patch(po *PullRequestsOptions) (interface{}, error) {
 	url := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id + "/patch"
 	return p.c.execute("GET", url, "")
 }
 
-func (p *PullRequests) Diff(po *PullRequestsOptions) interface{} {
+func (p *PullRequests) Diff(po *PullRequestsOptions) (interface{}, error) {
 	url := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id + "/diff"
 	return p.c.execute("GET", url, "")
 }
 
-func (p *PullRequests) Merge(po *PullRequestsOptions) interface{} {
+func (p *PullRequests) Merge(po *PullRequestsOptions) (interface{}, error) {
 	data := p.buildPullRequestBody(po)
 	url := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id + "/merge"
 	return p.c.execute("POST", url, data)
 }
 
-func (p *PullRequests) Decline(po *PullRequestsOptions) interface{} {
+func (p *PullRequests) Decline(po *PullRequestsOptions) (interface{}, error) {
 	data := p.buildPullRequestBody(po)
 	url := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id + "/decline"
 	return p.c.execute("POST", url, data)
 }
 
-func (p *PullRequests) GetComments(po *PullRequestsOptions) interface{} {
+func (p *PullRequests) GetComments(po *PullRequestsOptions) (interface{}, error) {
 	url := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id + "/comments/"
 	return p.c.execute("GET", url, "")
 }
 
-func (p *PullRequests) GetComment(po *PullRequestsOptions) interface{} {
+func (p *PullRequests) GetComment(po *PullRequestsOptions) (interface{}, error) {
 	url := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id + "/comments/" + po.Comment_id
 	return p.c.execute("GET", url, "")
 }

--- a/pullrequests.go
+++ b/pullrequests.go
@@ -13,71 +13,71 @@ type PullRequests struct {
 
 func (p *PullRequests) Create(po *PullRequestsOptions) (interface{}, error) {
 	data := p.buildPullRequestBody(po)
-	url := p.c.requestUrl("/repositories/%s/%s/pullrequests/", po.Owner, po.Repo_slug)
-	return p.c.execute("POST", url, data)
+	urlStr := p.c.requestUrl("/repositories/%s/%s/pullrequests/", po.Owner, po.Repo_slug)
+	return p.c.execute("POST", urlStr, data)
 }
 
 func (p *PullRequests) Update(po *PullRequestsOptions) (interface{}, error) {
 	data := p.buildPullRequestBody(po)
-	url := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id
-	return p.c.execute("PUT", url, data)
+	urlStr := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id
+	return p.c.execute("PUT", urlStr, data)
 }
 
 func (p *PullRequests) Gets(po *PullRequestsOptions) (interface{}, error) {
-	url := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/"
-	return p.c.execute("GET", url, "")
+	urlStr := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/"
+	return p.c.execute("GET", urlStr, "")
 }
 
 func (p *PullRequests) Get(po *PullRequestsOptions) (interface{}, error) {
-	url := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id
-	return p.c.execute("GET", url, "")
+	urlStr := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id
+	return p.c.execute("GET", urlStr, "")
 }
 
 func (p *PullRequests) Activities(po *PullRequestsOptions) (interface{}, error) {
-	url := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/activity"
-	return p.c.execute("GET", url, "")
+	urlStr := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/activity"
+	return p.c.execute("GET", urlStr, "")
 }
 
 func (p *PullRequests) Activity(po *PullRequestsOptions) (interface{}, error) {
-	url := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id + "/activity"
-	return p.c.execute("GET", url, "")
+	urlStr := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id + "/activity"
+	return p.c.execute("GET", urlStr, "")
 }
 
 func (p *PullRequests) Commits(po *PullRequestsOptions) (interface{}, error) {
-	url := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id + "/commits"
-	return p.c.execute("GET", url, "")
+	urlStr := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id + "/commits"
+	return p.c.execute("GET", urlStr, "")
 }
 
 func (p *PullRequests) Patch(po *PullRequestsOptions) (interface{}, error) {
-	url := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id + "/patch"
-	return p.c.execute("GET", url, "")
+	urlStr := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id + "/patch"
+	return p.c.execute("GET", urlStr, "")
 }
 
 func (p *PullRequests) Diff(po *PullRequestsOptions) (interface{}, error) {
-	url := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id + "/diff"
-	return p.c.execute("GET", url, "")
+	urlStr := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id + "/diff"
+	return p.c.execute("GET", urlStr, "")
 }
 
 func (p *PullRequests) Merge(po *PullRequestsOptions) (interface{}, error) {
 	data := p.buildPullRequestBody(po)
-	url := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id + "/merge"
-	return p.c.execute("POST", url, data)
+	urlStr := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id + "/merge"
+	return p.c.execute("POST", urlStr, data)
 }
 
 func (p *PullRequests) Decline(po *PullRequestsOptions) (interface{}, error) {
 	data := p.buildPullRequestBody(po)
-	url := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id + "/decline"
-	return p.c.execute("POST", url, data)
+	urlStr := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id + "/decline"
+	return p.c.execute("POST", urlStr, data)
 }
 
 func (p *PullRequests) GetComments(po *PullRequestsOptions) (interface{}, error) {
-	url := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id + "/comments/"
-	return p.c.execute("GET", url, "")
+	urlStr := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id + "/comments/"
+	return p.c.execute("GET", urlStr, "")
 }
 
 func (p *PullRequests) GetComment(po *PullRequestsOptions) (interface{}, error) {
-	url := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id + "/comments/" + po.Comment_id
-	return p.c.execute("GET", url, "")
+	urlStr := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.Repo_slug + "/pullrequests/" + po.Id + "/comments/" + po.Comment_id
+	return p.c.execute("GET", urlStr, "")
 }
 
 func (p *PullRequests) buildPullRequestBody(po *PullRequestsOptions) string {

--- a/repositories.go
+++ b/repositories.go
@@ -1,8 +1,6 @@
 package bitbucket
 
-import (
 //"github.com/k0kubun/pp"
-)
 
 type Repositories struct {
 	c                  *Client
@@ -15,7 +13,7 @@ type Repositories struct {
 	repositories
 }
 
-func (r *Repositories) ListForAccount(ro *RepositoriesOptions) interface{} {
+func (r *Repositories) ListForAccount(ro *RepositoriesOptions) (interface{}, error) {
 	url := r.c.requestUrl("/repositories/%s", ro.Owner)
 	if ro.Role != "" {
 		url += "?role=" + ro.Role
@@ -23,7 +21,7 @@ func (r *Repositories) ListForAccount(ro *RepositoriesOptions) interface{} {
 	return r.c.execute("GET", url, "")
 }
 
-func (r *Repositories) ListForTeam(ro *RepositoriesOptions) interface{} {
+func (r *Repositories) ListForTeam(ro *RepositoriesOptions) (interface{}, error) {
 	url := r.c.requestUrl("/repositories/%s", ro.Owner)
 	if ro.Role != "" {
 		url += "?role=" + ro.Role
@@ -31,7 +29,7 @@ func (r *Repositories) ListForTeam(ro *RepositoriesOptions) interface{} {
 	return r.c.execute("GET", url, "")
 }
 
-func (r *Repositories) ListPublic() interface{} {
+func (r *Repositories) ListPublic() (interface{}, error) {
 	url := r.c.requestUrl("/repositories/", "")
 	return r.c.execute("GET", url, "")
 }

--- a/repositories.go
+++ b/repositories.go
@@ -14,22 +14,22 @@ type Repositories struct {
 }
 
 func (r *Repositories) ListForAccount(ro *RepositoriesOptions) (interface{}, error) {
-	url := r.c.requestUrl("/repositories/%s", ro.Owner)
+	urlStr := r.c.requestUrl("/repositories/%s", ro.Owner)
 	if ro.Role != "" {
-		url += "?role=" + ro.Role
+		urlStr += "?role=" + ro.Role
 	}
-	return r.c.execute("GET", url, "")
+	return r.c.execute("GET", urlStr, "")
 }
 
 func (r *Repositories) ListForTeam(ro *RepositoriesOptions) (interface{}, error) {
-	url := r.c.requestUrl("/repositories/%s", ro.Owner)
+	urlStr := r.c.requestUrl("/repositories/%s", ro.Owner)
 	if ro.Role != "" {
-		url += "?role=" + ro.Role
+		urlStr += "?role=" + ro.Role
 	}
-	return r.c.execute("GET", url, "")
+	return r.c.execute("GET", urlStr, "")
 }
 
 func (r *Repositories) ListPublic() (interface{}, error) {
-	url := r.c.requestUrl("/repositories/", "")
-	return r.c.execute("GET", url, "")
+	urlStr := r.c.requestUrl("/repositories/", "")
+	return r.c.execute("GET", urlStr, "")
 }

--- a/repository.go
+++ b/repository.go
@@ -105,15 +105,15 @@ func (r *Repository) buildRepositoryBody(ro *RepositoryOptions) string {
 	return string(data)
 }
 
-func decodeRepository(json interface{}) (*Repository, error) {
-	jsonMap := json.(map[string]interface{})
+func decodeRepository(repoResponse interface{}) (*Repository, error) {
+	repoMap := repoResponse.(map[string]interface{})
 
-	if jsonMap["type"] == "error" {
-		return nil, DecodeError(jsonMap)
+	if repoMap["type"] == "error" {
+		return nil, DecodeError(repoMap)
 	}
 
 	var repository *Repository
-	err := mapstructure.Decode(jsonMap, repository)
+	err := mapstructure.Decode(repoMap, repository)
 	if err != nil {
 		return nil, err
 	}

--- a/repository.go
+++ b/repository.go
@@ -28,8 +28,8 @@ type Repository struct {
 
 func (r *Repository) Create(ro *RepositoryOptions) (*Repository, error) {
 	data := r.buildRepositoryBody(ro)
-	url := r.c.requestUrl("/repositories/%s/%s", ro.Owner, ro.Repo_slug)
-	response, err := r.c.execute("POST", url, data)
+	urlStr := r.c.requestUrl("/repositories/%s/%s", ro.Owner, ro.Repo_slug)
+	response, err := r.c.execute("POST", urlStr, data)
 	if err != nil {
 		return nil, err
 	}
@@ -38,8 +38,8 @@ func (r *Repository) Create(ro *RepositoryOptions) (*Repository, error) {
 }
 
 func (r *Repository) Get(ro *RepositoryOptions) (*Repository, error) {
-	url := r.c.requestUrl("/repositories/%s/%s", ro.Owner, ro.Repo_slug)
-	response, err := r.c.execute("GET", url, "")
+	urlStr := r.c.requestUrl("/repositories/%s/%s", ro.Owner, ro.Repo_slug)
+	response, err := r.c.execute("GET", urlStr, "")
 	if err != nil {
 		return nil, err
 	}
@@ -48,18 +48,18 @@ func (r *Repository) Get(ro *RepositoryOptions) (*Repository, error) {
 }
 
 func (r *Repository) Delete(ro *RepositoryOptions) (interface{}, error) {
-	url := r.c.requestUrl("/repositories/%s/%s", ro.Owner, ro.Repo_slug)
-	return r.c.execute("DELETE", url, "")
+	urlStr := r.c.requestUrl("/repositories/%s/%s", ro.Owner, ro.Repo_slug)
+	return r.c.execute("DELETE", urlStr, "")
 }
 
 func (r *Repository) ListWatchers(ro *RepositoryOptions) (interface{}, error) {
-	url := r.c.requestUrl("/repositories/%s/%s/watchers", ro.Owner, ro.Repo_slug)
-	return r.c.execute("GET", url, "")
+	urlStr := r.c.requestUrl("/repositories/%s/%s/watchers", ro.Owner, ro.Repo_slug)
+	return r.c.execute("GET", urlStr, "")
 }
 
 func (r *Repository) ListForks(ro *RepositoryOptions) (interface{}, error) {
-	url := r.c.requestUrl("/repositories/%s/%s/forks", ro.Owner, ro.Repo_slug)
-	return r.c.execute("GET", url, "")
+	urlStr := r.c.requestUrl("/repositories/%s/%s/forks", ro.Owner, ro.Repo_slug)
+	return r.c.execute("GET", urlStr, "")
 }
 
 func (r *Repository) buildRepositoryBody(ro *RepositoryOptions) string {

--- a/repository.go
+++ b/repository.go
@@ -26,32 +26,38 @@ type Repository struct {
 	Links       map[string]interface{}
 }
 
-func (r *Repository) Create(ro *RepositoryOptions) (Repository, error) {
+func (r *Repository) Create(ro *RepositoryOptions) (*Repository, error) {
 	data := r.buildRepositoryBody(ro)
 	url := r.c.requestUrl("/repositories/%s/%s", ro.Owner, ro.Repo_slug)
-	response := r.c.execute("POST", url, data)
+	response, err := r.c.execute("POST", url, data)
+	if err != nil {
+		return nil, err
+	}
 
 	return decodeRepository(response)
 }
 
-func (r *Repository) Get(ro *RepositoryOptions) (Repository, error) {
+func (r *Repository) Get(ro *RepositoryOptions) (*Repository, error) {
 	url := r.c.requestUrl("/repositories/%s/%s", ro.Owner, ro.Repo_slug)
-	response := r.c.execute("GET", url, "")
+	response, err := r.c.execute("GET", url, "")
+	if err != nil {
+		return nil, err
+	}
 
 	return decodeRepository(response)
 }
 
-func (r *Repository) Delete(ro *RepositoryOptions) interface{} {
+func (r *Repository) Delete(ro *RepositoryOptions) (interface{}, error) {
 	url := r.c.requestUrl("/repositories/%s/%s", ro.Owner, ro.Repo_slug)
 	return r.c.execute("DELETE", url, "")
 }
 
-func (r *Repository) ListWatchers(ro *RepositoryOptions) interface{} {
+func (r *Repository) ListWatchers(ro *RepositoryOptions) (interface{}, error) {
 	url := r.c.requestUrl("/repositories/%s/%s/watchers", ro.Owner, ro.Repo_slug)
 	return r.c.execute("GET", url, "")
 }
 
-func (r *Repository) ListForks(ro *RepositoryOptions) interface{} {
+func (r *Repository) ListForks(ro *RepositoryOptions) (interface{}, error) {
 	url := r.c.requestUrl("/repositories/%s/%s/forks", ro.Owner, ro.Repo_slug)
 	return r.c.execute("GET", url, "")
 }
@@ -99,17 +105,17 @@ func (r *Repository) buildRepositoryBody(ro *RepositoryOptions) string {
 	return string(data)
 }
 
-func decodeRepository(json interface{}) (Repository, error) {
+func decodeRepository(json interface{}) (*Repository, error) {
 	jsonMap := json.(map[string]interface{})
 
 	if jsonMap["type"] == "error" {
-		return Repository{}, DecodeError(jsonMap)
+		return nil, DecodeError(jsonMap)
 	}
 
-	var repository Repository
-	err := mapstructure.Decode(jsonMap, &repository)
+	var repository *Repository
+	err := mapstructure.Decode(jsonMap, repository)
 	if err != nil {
-		return Repository{}, err
+		return nil, err
 	}
 
 	return repository, nil

--- a/teams.go
+++ b/teams.go
@@ -5,31 +5,31 @@ type Teams struct {
 }
 
 func (t *Teams) List(role string) (interface{}, error) {
-	url := t.c.requestUrl("/teams/?role=%s", role)
-	return t.c.execute("GET", url, "")
+	urlStr := t.c.requestUrl("/teams/?role=%s", role)
+	return t.c.execute("GET", urlStr, "")
 }
 
 func (t *Teams) Profile(teamname string) (interface{}, error) {
-	url := t.c.requestUrl("/teams/%s/", teamname)
-	return t.c.execute("GET", url, "")
+	urlStr := t.c.requestUrl("/teams/%s/", teamname)
+	return t.c.execute("GET", urlStr, "")
 }
 
 func (t *Teams) Members(teamname string) (interface{}, error) {
-	url := t.c.requestUrl("/teams/%s/members", teamname)
-	return t.c.execute("GET", url, "")
+	urlStr := t.c.requestUrl("/teams/%s/members", teamname)
+	return t.c.execute("GET", urlStr, "")
 }
 
 func (t *Teams) Followers(teamname string) (interface{}, error) {
-	url := t.c.requestUrl("/teams/%s/followers", teamname)
-	return t.c.execute("GET", url, "")
+	urlStr := t.c.requestUrl("/teams/%s/followers", teamname)
+	return t.c.execute("GET", urlStr, "")
 }
 
 func (t *Teams) Following(teamname string) (interface{}, error) {
-	url := t.c.requestUrl("/teams/%s/following", teamname)
-	return t.c.execute("GET", url, "")
+	urlStr := t.c.requestUrl("/teams/%s/following", teamname)
+	return t.c.execute("GET", urlStr, "")
 }
 
 func (t *Teams) Repositories(teamname string) (interface{}, error) {
-	url := t.c.requestUrl("/teams/%s/repositories", teamname)
-	return t.c.execute("GET", url, "")
+	urlStr := t.c.requestUrl("/teams/%s/repositories", teamname)
+	return t.c.execute("GET", urlStr, "")
 }

--- a/teams.go
+++ b/teams.go
@@ -1,37 +1,35 @@
 package bitbucket
 
-import ()
-
 type Teams struct {
 	c *Client
 }
 
-func (t *Teams) List(role string) interface{} {
+func (t *Teams) List(role string) (interface{}, error) {
 	url := t.c.requestUrl("/teams/?role=%s", role)
 	return t.c.execute("GET", url, "")
 }
 
-func (t *Teams) Profile(teamname string) interface{} {
+func (t *Teams) Profile(teamname string) (interface{}, error) {
 	url := t.c.requestUrl("/teams/%s/", teamname)
 	return t.c.execute("GET", url, "")
 }
 
-func (t *Teams) Members(teamname string) interface{} {
+func (t *Teams) Members(teamname string) (interface{}, error) {
 	url := t.c.requestUrl("/teams/%s/members", teamname)
 	return t.c.execute("GET", url, "")
 }
 
-func (t *Teams) Followers(teamname string) interface{} {
+func (t *Teams) Followers(teamname string) (interface{}, error) {
 	url := t.c.requestUrl("/teams/%s/followers", teamname)
 	return t.c.execute("GET", url, "")
 }
 
-func (t *Teams) Following(teamname string) interface{} {
+func (t *Teams) Following(teamname string) (interface{}, error) {
 	url := t.c.requestUrl("/teams/%s/following", teamname)
 	return t.c.execute("GET", url, "")
 }
 
-func (t *Teams) Repositories(teamname string) interface{} {
+func (t *Teams) Repositories(teamname string) (interface{}, error) {
 	url := t.c.requestUrl("/teams/%s/repositories", teamname)
 	return t.c.execute("GET", url, "")
 }

--- a/user.go
+++ b/user.go
@@ -7,12 +7,12 @@ type User struct {
 
 // Profile is getting the user data
 func (u *User) Profile() (interface{}, error) {
-	url := GetApiBaseURL() + "/user/"
-	return u.c.execute("GET", url, "")
+	urlStr := GetApiBaseURL() + "/user/"
+	return u.c.execute("GET", urlStr, "")
 }
 
 // Emails is getting user's emails
 func (u *User) Emails() (interface{}, error) {
-	url := GetApiBaseURL() + "/user/emails"
-	return u.c.execute("GET", url, "")
+	urlStr := GetApiBaseURL() + "/user/emails"
+	return u.c.execute("GET", urlStr, "")
 }

--- a/user.go
+++ b/user.go
@@ -6,13 +6,13 @@ type User struct {
 }
 
 // Profile is getting the user data
-func (u *User) Profile() interface{} {
+func (u *User) Profile() (interface{}, error) {
 	url := GetApiBaseURL() + "/user/"
 	return u.c.execute("GET", url, "")
 }
 
 // Emails is getting user's emails
-func (u *User) Emails() interface{} {
+func (u *User) Emails() (interface{}, error) {
 	url := GetApiBaseURL() + "/user/emails"
 	return u.c.execute("GET", url, "")
 }

--- a/users.go
+++ b/users.go
@@ -4,30 +4,30 @@ type Users struct {
 	c *Client
 }
 
-func (u *Users) Get(t string) interface{} {
+func (u *Users) Get(t string) (interface{}, error) {
 
 	url := GetApiBaseURL() + "/users/" + t + "/"
 	return u.c.execute("GET", url, "")
 }
 
-func (c *Client) Get(t string) interface{} {
+func (c *Client) Get(t string) (interface{}, error) {
 
 	url := GetApiBaseURL() + "/users/" + t + "/"
 	return c.execute("GET", url, "")
 }
 
-func (u *Users) Followers(t string) interface{} {
+func (u *Users) Followers(t string) (interface{}, error) {
 
 	url := GetApiBaseURL() + "/users/" + t + "/followers"
 	return u.c.execute("GET", url, "")
 }
 
-func (u *Users) Following(t string) interface{} {
+func (u *Users) Following(t string) (interface{}, error) {
 
 	url := GetApiBaseURL() + "/users/" + t + "/following"
 	return u.c.execute("GET", url, "")
 }
-func (u *Users) Repositories(t string) interface{} {
+func (u *Users) Repositories(t string) (interface{}, error) {
 
 	url := GetApiBaseURL() + "/users/" + t + "/repositories"
 	return u.c.execute("GET", url, "")

--- a/users.go
+++ b/users.go
@@ -6,29 +6,29 @@ type Users struct {
 
 func (u *Users) Get(t string) (interface{}, error) {
 
-	url := GetApiBaseURL() + "/users/" + t + "/"
-	return u.c.execute("GET", url, "")
+	urlStr := GetApiBaseURL() + "/users/" + t + "/"
+	return u.c.execute("GET", urlStr, "")
 }
 
 func (c *Client) Get(t string) (interface{}, error) {
 
-	url := GetApiBaseURL() + "/users/" + t + "/"
-	return c.execute("GET", url, "")
+	urlStr := GetApiBaseURL() + "/users/" + t + "/"
+	return c.execute("GET", urlStr, "")
 }
 
 func (u *Users) Followers(t string) (interface{}, error) {
 
-	url := GetApiBaseURL() + "/users/" + t + "/followers"
-	return u.c.execute("GET", url, "")
+	urlStr := GetApiBaseURL() + "/users/" + t + "/followers"
+	return u.c.execute("GET", urlStr, "")
 }
 
 func (u *Users) Following(t string) (interface{}, error) {
 
-	url := GetApiBaseURL() + "/users/" + t + "/following"
-	return u.c.execute("GET", url, "")
+	urlStr := GetApiBaseURL() + "/users/" + t + "/following"
+	return u.c.execute("GET", urlStr, "")
 }
 func (u *Users) Repositories(t string) (interface{}, error) {
 
-	url := GetApiBaseURL() + "/users/" + t + "/repositories"
-	return u.c.execute("GET", url, "")
+	urlStr := GetApiBaseURL() + "/users/" + t + "/repositories"
+	return u.c.execute("GET", urlStr, "")
 }

--- a/webhooks.go
+++ b/webhooks.go
@@ -2,8 +2,9 @@ package bitbucket
 
 import (
 	"encoding/json"
-	"github.com/k0kubun/pp"
 	"os"
+
+	"github.com/k0kubun/pp"
 )
 
 type Webhooks struct {
@@ -39,29 +40,29 @@ func (r *Webhooks) buildWebhooksBody(ro *WebhooksOptions) string {
 	return string(data)
 }
 
-func (r *Webhooks) Gets(ro *WebhooksOptions) interface{} {
+func (r *Webhooks) Gets(ro *WebhooksOptions) (interface{}, error) {
 	url := r.c.requestUrl("/repositories/%s/%s/hooks/", ro.Owner, ro.Repo_slug)
 	return r.c.execute("GET", url, "")
 }
 
-func (r *Webhooks) Create(ro *WebhooksOptions) interface{} {
+func (r *Webhooks) Create(ro *WebhooksOptions) (interface{}, error) {
 	data := r.buildWebhooksBody(ro)
 	url := r.c.requestUrl("/repositories/%s/%s/hooks", ro.Owner, ro.Repo_slug)
 	return r.c.execute("POST", url, data)
 }
 
-func (r *Webhooks) Get(ro *WebhooksOptions) interface{} {
+func (r *Webhooks) Get(ro *WebhooksOptions) (interface{}, error) {
 	url := r.c.requestUrl("/repositories/%s/%s/hooks/%s", ro.Owner, ro.Repo_slug, ro.Uuid)
 	return r.c.execute("GET", url, "")
 }
 
-func (r *Webhooks) Update(ro *WebhooksOptions) interface{} {
+func (r *Webhooks) Update(ro *WebhooksOptions) (interface{}, error) {
 	data := r.buildWebhooksBody(ro)
 	url := r.c.requestUrl("/repositories/%s/%s/hooks/%s", ro.Owner, ro.Repo_slug, ro.Uuid)
 	return r.c.execute("PUT", url, data)
 }
 
-func (r *Webhooks) Delete(ro *WebhooksOptions) interface{} {
+func (r *Webhooks) Delete(ro *WebhooksOptions) (interface{}, error) {
 	url := r.c.requestUrl("/repositories/%s/%s/hooks/%s", ro.Owner, ro.Repo_slug, ro.Uuid)
 	return r.c.execute("DELETE", url, "")
 }

--- a/webhooks.go
+++ b/webhooks.go
@@ -41,30 +41,30 @@ func (r *Webhooks) buildWebhooksBody(ro *WebhooksOptions) string {
 }
 
 func (r *Webhooks) Gets(ro *WebhooksOptions) (interface{}, error) {
-	url := r.c.requestUrl("/repositories/%s/%s/hooks/", ro.Owner, ro.Repo_slug)
-	return r.c.execute("GET", url, "")
+	urlStr := r.c.requestUrl("/repositories/%s/%s/hooks/", ro.Owner, ro.Repo_slug)
+	return r.c.execute("GET", urlStr, "")
 }
 
 func (r *Webhooks) Create(ro *WebhooksOptions) (interface{}, error) {
 	data := r.buildWebhooksBody(ro)
-	url := r.c.requestUrl("/repositories/%s/%s/hooks", ro.Owner, ro.Repo_slug)
-	return r.c.execute("POST", url, data)
+	urlStr := r.c.requestUrl("/repositories/%s/%s/hooks", ro.Owner, ro.Repo_slug)
+	return r.c.execute("POST", urlStr, data)
 }
 
 func (r *Webhooks) Get(ro *WebhooksOptions) (interface{}, error) {
-	url := r.c.requestUrl("/repositories/%s/%s/hooks/%s", ro.Owner, ro.Repo_slug, ro.Uuid)
-	return r.c.execute("GET", url, "")
+	urlStr := r.c.requestUrl("/repositories/%s/%s/hooks/%s", ro.Owner, ro.Repo_slug, ro.Uuid)
+	return r.c.execute("GET", urlStr, "")
 }
 
 func (r *Webhooks) Update(ro *WebhooksOptions) (interface{}, error) {
 	data := r.buildWebhooksBody(ro)
-	url := r.c.requestUrl("/repositories/%s/%s/hooks/%s", ro.Owner, ro.Repo_slug, ro.Uuid)
-	return r.c.execute("PUT", url, data)
+	urlStr := r.c.requestUrl("/repositories/%s/%s/hooks/%s", ro.Owner, ro.Repo_slug, ro.Uuid)
+	return r.c.execute("PUT", urlStr, data)
 }
 
 func (r *Webhooks) Delete(ro *WebhooksOptions) (interface{}, error) {
-	url := r.c.requestUrl("/repositories/%s/%s/hooks/%s", ro.Owner, ro.Repo_slug, ro.Uuid)
-	return r.c.execute("DELETE", url, "")
+	urlStr := r.c.requestUrl("/repositories/%s/%s/hooks/%s", ro.Owner, ro.Repo_slug, ro.Uuid)
+	return r.c.execute("DELETE", urlStr, "")
 }
 
 //


### PR DESCRIPTION
Returning a separate `err error` as the last return value is the Go way.
Which is perfectly implemented in GRPC for example.

Also pagination was not implemented at all (only Pagelen was set)