### PR TITLE
Webhook fix & 201 status support

### DIFF
--- a/client.go
+++ b/client.go
@@ -93,7 +93,7 @@ func (c *Client) execute(method string, urlStr string, text string) (interface{}
 		defer resp.Body.Close()
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if (resp.StatusCode != http.StatusOK) && (resp.StatusCode != http.StatusCreated) {
 		return nil, fmt.Errorf(resp.Status)
 	}
 

--- a/webhooks.go
+++ b/webhooks.go
@@ -25,11 +25,7 @@ func (r *Webhooks) buildWebhooksBody(ro *WebhooksOptions) string {
 		body["active"] = ro.Active
 	}
 
-	if n := len(ro.Events); n > 0 {
-		for i, event := range ro.Events {
-			body["events"].([]string)[i] = event
-		}
-	}
+	body["events"] = ro.Events
 
 	data, err := json.Marshal(body)
 	if err != nil {


### PR DESCRIPTION
Hey.

This fixes a small (what i believe to be) webhook bug, and adds support for http code 201.

**The bug:**
Given the following bit of code:
```
opts := &bitbucket.WebhooksOptions{
                                Owner:    "owner",
                                Repo_slug: "foobar",
                        }

opts.Events = []string{
                                "repo:push",
                                "pullrequest:fulfilled",
                        }
```

The library will panic with a type cast.
```
go run main.go 
panic: interface conversion: interface {} is nil, not []string

goroutine 1 [running]:
github.com/ktrysmt/go-bitbucket.(*Webhooks).buildWebhooksBody(0xc42000e048, 0xc420272070, 0x0, 0x0)
	/Users/calum/src/github.com/ktrysmt/go-bitbucket/webhooks.go:30 +0x363
github.com/ktrysmt/go-bitbucket.(*Webhooks).Create(0xc42000e048, 0xc420272070, 0xc42013beb0, 0x1, 0x1, 0xc420286c00)
	/Users/calum/src/github.com/ktrysmt/go-bitbucket/webhooks.go:49 +0x4d
```

This also adds HTTP 201, which is what the bitbucket api will return on creation of a resource (such as a webhook)

Cheers