### PR TITLE
Fix nil pointer error

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -112,7 +112,7 @@ func decodeRepository(repoResponse interface{}) (*Repository, error) {
 		return nil, DecodeError(repoMap)
 	}
 
-	var repository *Repository
+	var repository = new(Repository)
 	err := mapstructure.Decode(repoMap, repository)
 	if err != nil {
 		return nil, err

--- a/tests/branchrestrictions_test.go
+++ b/tests/branchrestrictions_test.go
@@ -1,9 +1,10 @@
 package tests
 
 import (
-	"github.com/ktrysmt/go-bitbucket"
 	"os"
 	"testing"
+
+	"github.com/ktrysmt/go-bitbucket"
 )
 
 var (
@@ -43,7 +44,7 @@ func TestCreateBranchRestrictionsKindPush(t *testing.T) {
 		Kind:      "push",
 		Users:     []string{user},
 	}
-	res := c.Repositories.BranchRestrictions.Create(opt)
+	res, _ := c.Repositories.BranchRestrictions.Create(opt)
 	jsonMap := res.(map[string]interface{})
 	if jsonMap["type"] != "branchrestriction" {
 		t.Error("is not branchrestriction type")
@@ -64,7 +65,7 @@ func TestCreateBranchRestrictionsKindRequirePassingBuilds(t *testing.T) {
 		Kind:      "require_passing_builds_to_merge",
 		Value:     2,
 	}
-	res := c.Repositories.BranchRestrictions.Create(opt)
+	res, _ := c.Repositories.BranchRestrictions.Create(opt)
 	jsonMap := res.(map[string]interface{})
 	if jsonMap["type"] != "branchrestriction" {
 		t.Error("is not branchrestriction type")

--- a/tests/user_test.go
+++ b/tests/user_test.go
@@ -1,9 +1,10 @@
 package tests
 
 import (
-	"github.com/ktrysmt/go-bitbucket"
 	"os"
 	"testing"
+
+	"github.com/ktrysmt/go-bitbucket"
 )
 
 func TestProfile(t *testing.T) {
@@ -21,7 +22,7 @@ func TestProfile(t *testing.T) {
 
 	c := bitbucket.NewBasicAuth(user, pass)
 
-	res := c.User.Profile()
+	res, _ := c.User.Profile()
 
 	jsonMap := res.(map[string]interface{})
 


### PR DESCRIPTION
`decodeRepository` panics because a nil point is being passed to `mapstructure.Decode`.
I fixed some of the tests as well.