### PR TITLE
Fix wrong field name

### DIFF
--- a/client.go
+++ b/client.go
@@ -36,7 +36,7 @@ type auth struct {
 
 // Uses the Client Credentials Grant oauth2 flow to authenticate to Bitbucket
 func NewOAuthClientCredentials(i, s string) *Client {
-	a := &auth{app_id: i, secret: s}
+	a := &auth{appID: i, secret: s}
 	ctx := context.Background()
 	conf := &clientcredentials.Config{
 		ClientID:     i,


### PR DESCRIPTION
Apparently the previous commit introduced a bug which does results in failure when installing this package. The auth struct is initialised with app_id instead of appID.