### PR TITLE
Adding ability to create commit status. 

### DIFF
--- a/bitbucket.go
+++ b/bitbucket.go
@@ -61,6 +61,7 @@ type commits interface {
 	GetCommitStatus(opt CommitsOptions) (interface{}, error)
 	GiveApprove(opt CommitsOptions) (interface{}, error)
 	RemoveApprove(opt CommitsOptions) (interface{}, error)
+	CreateCommitStatus(cmo CommitsOptions, cso CommitStatusOptions) (interface{}, error)
 }
 
 type branchrestrictions interface {
@@ -137,6 +138,15 @@ type CommitsOptions struct {
 	Include     string `json:"include"`
 	Exclude     string `json:"exclude"`
 	CommentID   string `json:"comment_id"`
+}
+
+type CommitStatusOptions struct {
+	Key 		string `json:"key"`
+	Url 		string `json:"url"`
+	State 		string `json:"state"`
+	Name 		string `json:"name"`
+	Description string `json:"description"`
+
 }
 
 type BranchRestrictionsOptions struct {

--- a/commits.go
+++ b/commits.go
@@ -1,6 +1,9 @@
 package bitbucket
 
-import "net/url"
+import (
+	"net/url"
+	"encoding/json"
+)
 
 type Commits struct {
 	c *Client
@@ -46,6 +49,17 @@ func (cm *Commits) RemoveApprove(cmo *CommitsOptions) (interface{}, error) {
 	urlStr := cm.c.requestUrl("/repositories/%s/%s/commit/%s/approve", cmo.Owner, cmo.RepoSlug, cmo.Revision)
 	return cm.c.execute("DELETE", urlStr, "")
 }
+
+
+func (cm *Commits) CreateCommitStatus(cmo *CommitsOptions, cso *CommitStatusOptions) (interface{}, error) {
+	urlStr := cm.c.requestUrl("/repositories/%s/%s/commit/%s/statuses/build", cmo.Owner, cmo.RepoSlug, cmo.Revision)
+	data, err := json.Marshal(cso)
+	if err != nil {
+		return nil, err
+	}
+	return cm.c.execute("POST", urlStr, string(data))
+}
+
 
 func (cm *Commits) buildCommitsQuery(include, exclude string) string {
 


### PR DESCRIPTION
https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/commit/%7Bnode%7D/statuses/build

You can now create commit statuses by using code similar to the following:

```
co := bitbucket.CommitsOptions{
		Owner: "owner_name",
		RepoSlug: "repo_name",
		Revision: "sha",
	}

	cso := bitbucket.CommitStatusOptions{
		Key:		 "build", //cannot change, is a constant. 
		State:       "INPROGRESS",
		Url:         "http://www.example.com",
		Name:        "TravisCI",
		Description: "test message",
	}

	_, err := client.Repositories.Commits.CreateCommitStatus(&co, &cso)
```


---

While writing this PR, I did notice some oddities in the `go-bitbucket` repo, like all the unused interfaces in the bitbucket.go file, and the fact that all the interfaces specify concrete parameters, while the functions all require pointers (which causes go to panic). There also doesn't seem to be a comprehensive test suite either. 

Is that just code that needs to be cleaned up, or is there some other reason you have them?