### PR TITLE
add NewOAuthWithCode

### DIFF
--- a/client.go
+++ b/client.go
@@ -91,6 +91,25 @@ func NewOAuth(i, s string) *Client {
 	return injectClient(a)
 }
 
+// NewOAuthWithCode finishes the OAuth handshake with a given code
+// and returns a *Client
+func NewOAuthWithCode(i, s, c string) (*Client, string) {
+	a := &auth{appID: i, secret: s}
+	ctx := context.Background()
+	conf := &oauth2.Config{
+		ClientID:     i,
+		ClientSecret: s,
+		Endpoint:     bitbucket.Endpoint,
+	}
+
+	tok, err := conf.Exchange(ctx, c)
+	if err != nil {
+		log.Fatal(err)
+	}
+	a.token = *tok
+	return injectClient(a), tok.AccessToken
+}
+
 func NewOAuthbearerToken(t string) *Client {
 	a := &auth{bearerToken: t}
 	return injectClient(a)

--- a/downloads.go
+++ b/downloads.go
@@ -1,6 +1,5 @@
 package bitbucket
 
-
 type Downloads struct {
 	c *Client
 }
@@ -8,4 +7,9 @@ type Downloads struct {
 func (dl *Downloads) Create(do *DownloadsOptions) (interface{}, error) {
 	urlStr := dl.c.requestUrl("/repositories/%s/%s/downloads", do.Owner, do.RepoSlug)
 	return dl.c.executeFileUpload("POST", urlStr, do.FilePath, do.FileName)
+}
+
+func (dl *Downloads) List(do *DownloadsOptions) (interface{}, error) {
+	urlStr := dl.c.requestUrl("/repositories/%s/%s/downloads", do.Owner, do.RepoSlug)
+	return dl.c.execute("GET", urlStr, "")
 }


### PR DESCRIPTION
I currently integrate a backend with Bitbucket. For this I let the user authorise via Bitbucket so I can do actions on his behalf on this repositories.
Via my frontend I send the user to the Bitbucket OAuth login page with my `client_id`.
I receive the response including the code in my backend.

To be able to use your Bitbucket client I added a function `NewOAuthWithCode` which lets me instantiate an OAuth client with the already received `code`.
The code is then exchanged for a token and I return `*Client` _and_ the `AccessToken` because I will need the `AccessToken` for future requests of the user.