### PR TITLE
Fix incorrect module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/wzjgo1/go-bitbucket
+module github.com/ktrysmt/go-bitbucket
 
 go 1.12
 


### PR DESCRIPTION
Module path should match github url.

Incorrect name produces an error
```
$ go get github.com/ktrysmt/go-bitbucket@master
go: finding github.com/ktrysmt/go-bitbucket master
go: github.com/ktrysmt/go-bitbucket@v0.4.2-0.20190815151405-f538244ac470: parsing go.mod: unexpected module path "github.com/wzjgo1/go-bitbucket"
go: error loading module requirements
```