### PR TITLE
Removed accidental print

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -107,7 +107,6 @@ func (r *Repository) Get(ro *RepositoryOptions) (*Repository, error) {
 func (r *Repository) ListFiles(ro *RepositoryFilesOptions) ([]RepositoryFile, error) {
 	filePath := path.Join("/repositories", ro.Owner, ro.RepoSlug, "src", ro.Ref, ro.Path) + "/"
 	urlStr := r.c.requestUrl(filePath)
-	print(urlStr)
 	response, err := r.c.execute("GET", urlStr, "")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Sorry, there was a `print()` statement in that last commit. I've removed it.