### PR TITLE
Make `apiBaseURL` a client variable

### DIFF
--- a/bitbucket.go
+++ b/bitbucket.go
@@ -1,15 +1,5 @@
 package bitbucket
 
-var apiBaseURL = "https://api.bitbucket.org/2.0"
-
-func GetApiBaseURL() string {
-	return apiBaseURL
-}
-
-func SetApiBaseURL(urlStr string) {
-	apiBaseURL = urlStr
-}
-
 type users interface {
 	Get(username string) (interface{}, error)
 	Followers(username string) (interface{}, error)

--- a/client.go
+++ b/client.go
@@ -33,6 +33,7 @@ type Client struct {
 	Repositories *Repositories
 	Pagelen      uint64
 	MaxDepth     uint64
+	apiBaseURL   string
 
 	HttpClient *http.Client
 }
@@ -124,7 +125,7 @@ func NewBasicAuth(u, p string) *Client {
 }
 
 func injectClient(a *auth) *Client {
-	c := &Client{Auth: a, Pagelen: DEFAULT_PAGE_LENGTH, MaxDepth: DEFAULT_MAX_DEPTH}
+	c := &Client{Auth: a, Pagelen: DEFAULT_PAGE_LENGTH, MaxDepth: DEFAULT_MAX_DEPTH, apiBaseURL: "https://api.bitbucket.org/2.0"}
 	c.Repositories = &Repositories{
 		c:                  c,
 		PullRequests:       &PullRequests{c: c},
@@ -140,6 +141,14 @@ func injectClient(a *auth) *Client {
 	c.Teams = &Teams{c: c}
 	c.HttpClient = new(http.Client)
 	return c
+}
+
+func (c *Client) GetApiBaseURL() string {
+	return c.apiBaseURL
+}
+
+func (c *Client) SetApiBaseURL(urlStr string) {
+	c.apiBaseURL = urlStr
 }
 
 func (c *Client) executeRaw(method string, urlStr string, text string) ([]byte, error) {
@@ -334,7 +343,7 @@ func (c *Client) doRawRequest(req *http.Request, emptyResponse bool) ([]byte, er
 func (c *Client) requestUrl(template string, args ...interface{}) string {
 
 	if len(args) == 1 && args[0] == "" {
-		return GetApiBaseURL() + template
+		return c.apiBaseURL + template
 	}
-	return GetApiBaseURL() + fmt.Sprintf(template, args...)
+	return c.apiBaseURL + fmt.Sprintf(template, args...)
 }

--- a/pullrequests.go
+++ b/pullrequests.go
@@ -20,12 +20,12 @@ func (p *PullRequests) Create(po *PullRequestsOptions) (interface{}, error) {
 
 func (p *PullRequests) Update(po *PullRequestsOptions) (interface{}, error) {
 	data := p.buildPullRequestBody(po)
-	urlStr := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID
+	urlStr := p.c.GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID
 	return p.c.execute("PUT", urlStr, data)
 }
 
 func (p *PullRequests) Gets(po *PullRequestsOptions) (interface{}, error) {
-	urlStr := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/"
+	urlStr := p.c.GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/"
 
 	if po.States != nil && len(po.States) != 0 {
 		parsed, err := url.Parse(urlStr)
@@ -66,54 +66,54 @@ func (p *PullRequests) Gets(po *PullRequestsOptions) (interface{}, error) {
 }
 
 func (p *PullRequests) Get(po *PullRequestsOptions) (interface{}, error) {
-	urlStr := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID
+	urlStr := p.c.GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID
 	return p.c.execute("GET", urlStr, "")
 }
 
 func (p *PullRequests) Activities(po *PullRequestsOptions) (interface{}, error) {
-	urlStr := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/activity"
+	urlStr := p.c.GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/activity"
 	return p.c.execute("GET", urlStr, "")
 }
 
 func (p *PullRequests) Activity(po *PullRequestsOptions) (interface{}, error) {
-	urlStr := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID + "/activity"
+	urlStr := p.c.GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID + "/activity"
 	return p.c.execute("GET", urlStr, "")
 }
 
 func (p *PullRequests) Commits(po *PullRequestsOptions) (interface{}, error) {
-	urlStr := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID + "/commits"
+	urlStr := p.c.GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID + "/commits"
 	return p.c.execute("GET", urlStr, "")
 }
 
 func (p *PullRequests) Patch(po *PullRequestsOptions) (interface{}, error) {
-	urlStr := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID + "/patch"
+	urlStr := p.c.GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID + "/patch"
 	return p.c.execute("GET", urlStr, "")
 }
 
 func (p *PullRequests) Diff(po *PullRequestsOptions) (interface{}, error) {
-	urlStr := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID + "/diff"
+	urlStr := p.c.GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID + "/diff"
 	return p.c.execute("GET", urlStr, "")
 }
 
 func (p *PullRequests) Merge(po *PullRequestsOptions) (interface{}, error) {
 	data := p.buildPullRequestBody(po)
-	urlStr := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID + "/merge"
+	urlStr := p.c.GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID + "/merge"
 	return p.c.execute("POST", urlStr, data)
 }
 
 func (p *PullRequests) Decline(po *PullRequestsOptions) (interface{}, error) {
 	data := p.buildPullRequestBody(po)
-	urlStr := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID + "/decline"
+	urlStr := p.c.GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID + "/decline"
 	return p.c.execute("POST", urlStr, data)
 }
 
 func (p *PullRequests) GetComments(po *PullRequestsOptions) (interface{}, error) {
-	urlStr := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID + "/comments/"
+	urlStr := p.c.GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID + "/comments/"
 	return p.c.execute("GET", urlStr, "")
 }
 
 func (p *PullRequests) GetComment(po *PullRequestsOptions) (interface{}, error) {
-	urlStr := GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID + "/comments/" + po.CommentID
+	urlStr := p.c.GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID + "/comments/" + po.CommentID
 	return p.c.execute("GET", urlStr, "")
 }
 

--- a/repositories.go
+++ b/repositories.go
@@ -21,11 +21,11 @@ type Repositories struct {
 }
 
 type RepositoriesRes struct {
-	Page    int32
-	Pagelen int32
+	Page     int32
+	Pagelen  int32
 	MaxDepth int32
-	Size    int32
-	Items   []Repository
+	Size     int32
+	Items    []Repository
 }
 
 func (r *Repositories) ListForAccount(ro *RepositoriesOptions) (*RepositoriesRes, error) {
@@ -53,7 +53,7 @@ func (r *Repositories) ListForTeam(ro *RepositoriesOptions) (*RepositoriesRes, e
 }
 
 func (r *Repositories) ListPublic() (interface{}, error) {
-	urlStr := r.c.requestUrl("/repositories/", "")
+	urlStr := r.c.requestUrl("/repositories/")
 	repos, err := r.c.execute("GET", urlStr, "")
 	if err != nil {
 		return nil, err
@@ -96,11 +96,11 @@ func decodeRepositorys(reposResponse interface{}) (*RepositoriesRes, error) {
 	}
 
 	repositories := RepositoriesRes{
-		Page:    int32(page),
-		Pagelen: int32(pagelen),
+		Page:     int32(page),
+		Pagelen:  int32(pagelen),
 		MaxDepth: int32(max_depth),
-		Size:    int32(size),
-		Items:   repos,
+		Size:     int32(size),
+		Items:    repos,
 	}
 	return &repositories, nil
 }

--- a/user.go
+++ b/user.go
@@ -7,12 +7,12 @@ type User struct {
 
 // Profile is getting the user data
 func (u *User) Profile() (interface{}, error) {
-	urlStr := GetApiBaseURL() + "/user/"
+	urlStr := u.c.GetApiBaseURL() + "/user/"
 	return u.c.execute("GET", urlStr, "")
 }
 
 // Emails is getting user's emails
 func (u *User) Emails() (interface{}, error) {
-	urlStr := GetApiBaseURL() + "/user/emails"
+	urlStr := u.c.GetApiBaseURL() + "/user/emails"
 	return u.c.execute("GET", urlStr, "")
 }

--- a/users.go
+++ b/users.go
@@ -6,29 +6,29 @@ type Users struct {
 
 func (u *Users) Get(t string) (interface{}, error) {
 
-	urlStr := GetApiBaseURL() + "/users/" + t + "/"
+	urlStr := u.c.GetApiBaseURL() + "/users/" + t + "/"
 	return u.c.execute("GET", urlStr, "")
 }
 
 func (c *Client) Get(t string) (interface{}, error) {
 
-	urlStr := GetApiBaseURL() + "/users/" + t + "/"
+	urlStr := c.GetApiBaseURL() + "/users/" + t + "/"
 	return c.execute("GET", urlStr, "")
 }
 
 func (u *Users) Followers(t string) (interface{}, error) {
 
-	urlStr := GetApiBaseURL() + "/users/" + t + "/followers"
+	urlStr := u.c.GetApiBaseURL() + "/users/" + t + "/followers"
 	return u.c.execute("GET", urlStr, "")
 }
 
 func (u *Users) Following(t string) (interface{}, error) {
 
-	urlStr := GetApiBaseURL() + "/users/" + t + "/following"
+	urlStr := u.c.GetApiBaseURL() + "/users/" + t + "/following"
 	return u.c.execute("GET", urlStr, "")
 }
 func (u *Users) Repositories(t string) (interface{}, error) {
 
-	urlStr := GetApiBaseURL() + "/users/" + t + "/repositories"
+	urlStr := u.c.GetApiBaseURL() + "/users/" + t + "/repositories"
 	return u.c.execute("GET", urlStr, "")
 }


### PR DESCRIPTION
Move the `apiBaseURL` from a global variable to a client variable, which should allow accessing different API's concurrently.

This is a breaking change for all users which were using `GetApiBaseURL()` or `SetApiBaseURL()`.

Solves #79 

