### PR TITLE
fix GetDiff to use executeRaw() internally.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,23 @@
 .DEFAULT_GOAL := help
 
 env: ## check env for e2e testing
-	ifndef BITBUCKET_TEST_USERNAME
-	  $(error `BITBUCKET_TEST_USERNAME` is not set)
-	endif
-	ifndef BITBUCKET_TEST_PASSWORD
-	  $(error `BITBUCKET_TEST_PASSWORD` is not set)
-	endif
-	ifndef BITBUCKET_TEST_OWNER
-	  $(error `BITBUCKET_TEST_OWNER` is not set)
-	endif
-	ifndef BITBUCKET_TEST_REPOSLUG
-	  $(error `BITBUCKET_TEST_REPOSLUG` is not set)
-	endif
+ifndef BITBUCKET_TEST_USERNAME
+	$(error `BITBUCKET_TEST_USERNAME` is not set)
+endif
+ifndef BITBUCKET_TEST_PASSWORD
+	$(error `BITBUCKET_TEST_PASSWORD` is not set)
+endif
+ifndef BITBUCKET_TEST_OWNER
+	$(error `BITBUCKET_TEST_OWNER` is not set)
+endif
+ifndef BITBUCKET_TEST_REPOSLUG
+	$(error `BITBUCKET_TEST_REPOSLUG` is not set)
+endif
 
 test: env ## run go test all
 	go test -v ./tests
 
-help: ## print this help 
+help: ## print this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: test help

--- a/diff.go
+++ b/diff.go
@@ -6,7 +6,7 @@ type Diff struct {
 
 func (d *Diff) GetDiff(do *DiffOptions) (interface{}, error) {
 	urlStr := d.c.requestUrl("/repositories/%s/%s/diff/%s", do.Owner, do.RepoSlug, do.Spec)
-	return d.c.execute("GET", urlStr, "")
+	return d.c.executeRaw("GET", urlStr, "diff")
 }
 
 func (d *Diff) GetPatch(do *DiffOptions) (interface{}, error) {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/golang/protobuf v1.0.0
+	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
 	github.com/k0kubun/pp v2.3.0+incompatible
 	github.com/mattn/go-colorable v0.0.9
 	github.com/mattn/go-isatty v0.0.3

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,17 @@
 github.com/golang/protobuf v1.0.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 h1:uC1QfSlInpQF+M0ao65imhwqKnz3Q2z/d8PWZRMQvDM=
+github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
+github.com/k0kubun/pp v2.3.0+incompatible h1:EKhKbi34VQDWJtq+zpsKSEhkHHs9w2P8Izbq8IhLVSo=
 github.com/k0kubun/pp v2.3.0+incompatible/go.mod h1:GWse8YhT0p8pT4ir3ZgBbfZild3tgzSScAn6HmfYukg=
+github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRUIY4=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-isatty v0.0.3 h1:ns/ykhmWi7G9O+8a448SecJU3nSMBXJfqQkl0upE1jI=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mitchellh/mapstructure v0.0.0-20180220230111-00c29f56e238 h1:+MZW2uvHgN8kYvksEN3f7eFL2wpzk0GxmlFsMybWc7E=
 github.com/mitchellh/mapstructure v0.0.0-20180220230111-00c29f56e238/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01 h1:po1f06KS05FvIQQA2pMuOWZAUXiy1KYdIf0ElUU2Hhc=
 golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/oauth2 v0.0.0-20180227000427-d7d64896b5ff h1:WbI0V2v8RZPTlOMrecBqqba3029Z6l7jeFySSGaN/jk=
 golang.org/x/oauth2 v0.0.0-20180227000427-d7d64896b5ff/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sys v0.0.0-20180224232135-f6cff0780e54/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 google.golang.org/appengine v1.0.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/tests/diff_test.go
+++ b/tests/diff_test.go
@@ -1,0 +1,42 @@
+package tests
+
+import (
+	"os"
+	"testing"
+
+	"github.com/k0kubun/pp"
+	"github.com/ktrysmt/go-bitbucket"
+)
+
+func TestDiff(t *testing.T) {
+
+	user := os.Getenv("BITBUCKET_TEST_USERNAME")
+	pass := os.Getenv("BITBUCKET_TEST_PASSWORD")
+	owner := os.Getenv("BITBUCKET_TEST_OWNER")
+	repo := os.Getenv("BITBUCKET_TEST_REPOSLUG")
+
+	if user == "" {
+		t.Error("BITBUCKET_TEST_USERNAME is empty.")
+	}
+
+	if pass == "" {
+		t.Error("BITBUCKET_TEST_PASSWORD is empty.")
+	}
+
+	c := bitbucket.NewBasicAuth(user, pass)
+
+	spec := "master..develop"
+
+	opt := &bitbucket.DiffOptions{
+		Owner:    owner,
+		RepoSlug: repo,
+		Spec:     spec,
+	}
+	res, _ := c.Repositories.Diff.GetDiff(opt)
+
+	pp.Println(res)
+
+	if res == nil {
+		t.Error("It could not get the raw response.")
+	}
+}


### PR DESCRIPTION
Bitbuckets' diff returns a response as plain text because It should use executeRaw(and doRawRequest) instead of execute(and doRequest) by inside.

ref: [/2.0/repositories/{workspace}/{repo_slug}/diff/{spec}](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/diff/%7Bspec%7D)

