### PR TITLE
Use io.ReadCloser + json.NewDecoder

### DIFF
--- a/client.go
+++ b/client.go
@@ -323,7 +323,7 @@ func (c *Client) doRawRequest(req *http.Request, emptyResponse bool) (io.ReadClo
 
 	if (resp.StatusCode != http.StatusOK) && (resp.StatusCode != http.StatusCreated) {
 		resp.Body.Close()
-		return nil, fmt.Errorf("%v (%s)", resp.Status, req.URL.String())
+		return nil, fmt.Errorf(resp.Status)
 	}
 
 	if emptyResponse {

--- a/repository.go
+++ b/repository.go
@@ -2,6 +2,7 @@ package bitbucket
 
 import (
 	"encoding/json"
+	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
@@ -162,7 +163,12 @@ func (r *Repository) GetFileBlob(ro *RepositoryBlobOptions) (*RepositoryBlob, er
 		return nil, err
 	}
 
-	blob := RepositoryBlob{Content: response}
+	content, err := ioutil.ReadAll(response)
+	if err != nil {
+		return nil, err
+	}
+	
+	blob := RepositoryBlob{Content: content}
 
 	return &blob, nil
 }


### PR DESCRIPTION
PR to take an attempt at #71 

To use `json.NewDecoder`, we need to use the I/O stream from the HTTP response object.

This is merely a starting point.