### PR TITLE
Pull request reviewers as uuid and strong user type

### DIFF
--- a/bitbucket.go
+++ b/bitbucket.go
@@ -8,7 +8,7 @@ type users interface {
 }
 
 type user interface {
-	Profile() (interface{}, error)
+	Profile() (*User, error)
 	Emails() (interface{}, error)
 }
 

--- a/pullrequests.go
+++ b/pullrequests.go
@@ -130,8 +130,8 @@ func (p *PullRequests) buildPullRequestBody(po *PullRequestsOptions) string {
 
 	if n := len(po.Reviewers); n > 0 {
 		body["reviewers"] = make([]map[string]string, n)
-		for i, user := range po.Reviewers {
-			body["reviewers"].([]map[string]string)[i] = map[string]string{"username": user}
+		for i, uuid := range po.Reviewers {
+			body["reviewers"].([]map[string]string)[i] = map[string]string{"uuid": uuid}
 		}
 	}
 

--- a/user.go
+++ b/user.go
@@ -1,18 +1,52 @@
 package bitbucket
 
+import (
+	"github.com/mitchellh/mapstructure"
+)
+
 // User is the sub struct of Client
+// Reference: https://developer.atlassian.com/bitbucket/api/2/reference/resource/user
 type User struct {
-	c *Client
+	c             *Client
+	Uuid          string
+	Username      string
+	Nickname      string
+	Website       string
+	AccountStatus string `mapstructure:"account_status"`
+	DisplayName   string `mapstructure:"display_name"`
+	CreatedOn     string `mapstructure:"created_on"`
+	Has2faEnabled bool   `mapstructure:"has_2fa_enabled"`
+	Links         map[string]interface{}
 }
 
 // Profile is getting the user data
-func (u *User) Profile() (interface{}, error) {
+func (u *User) Profile() (*User, error) {
 	urlStr := u.c.GetApiBaseURL() + "/user/"
-	return u.c.execute("GET", urlStr, "")
+	response, err := u.c.execute("GET", urlStr, "")
+	if err != nil {
+		return nil, err
+	}
+	return decodeUser(response)
 }
 
 // Emails is getting user's emails
 func (u *User) Emails() (interface{}, error) {
 	urlStr := u.c.GetApiBaseURL() + "/user/emails"
 	return u.c.execute("GET", urlStr, "")
+}
+
+func decodeUser(userResponse interface{}) (*User, error) {
+	userMap := userResponse.(map[string]interface{})
+
+	if userMap["type"] == "error" {
+		return nil, DecodeError(userMap)
+	}
+
+	var user = new(User)
+	err := mapstructure.Decode(userMap, user)
+	if err != nil {
+		return nil, err
+	}
+
+	return user, nil
 }


### PR DESCRIPTION
### Goal

Pull request with reviewers can't be submitted anymore due to this [API deprecation](https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-changes-gdpr/#removal-of-usernames-from-user-referencing-apis). This change replace `username` by `uuid` which seems to be the only way to submit PR with reviewers.

Another change is also introduced to have strong type on the `User` profile resource.

### Breaking changes

Reviewers must be submitted as `uuid` and not `username`. Note that curly braces surround the uuid. See [documentation](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/pullrequests)

