### PR TITLE
fix uploads

### DIFF
--- a/client.go
+++ b/client.go
@@ -304,6 +304,10 @@ func (c *Client) doRequest(req *http.Request, emptyResponse bool) (interface{}, 
 	if err != nil {
 		return nil, err
 	}
+	if emptyResponse {
+		return nil, nil
+	}
+
 	defer resBody.Close()
 
 	var result interface{}


### PR DESCRIPTION
Using the `Downloads.Create` Endpoint currently fails because the request body is missing.

The stacktrace looks like this:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x7a5e83]

goroutine 1 [running]:
github.com/ktrysmt/go-bitbucket.(*Client).doRequest(0xc000340000, 0xc00057cd00, 0xdff701, 0x0, 0x0, 0x0, 0x0)
        /home/fabian/go/pkg/mod/github.com/ktrysmt/go-bitbucket@v0.6.5/client.go:307 +0xa3
github.com/ktrysmt/go-bitbucket.(*Client).executeFileUpload(0xc000340000, 0xdd66ff, 0x4, 0xc0002fc000, 0x41, 0x7ffc3fa5126e, 0x28, 0x7ffc3fa51285, 0x11, 0x0, ...)
        /home/fabian/go/pkg/mod/github.com/ktrysmt/go-bitbucket@v0.6.5/client.go:285 +0x3d3
github.com/ktrysmt/go-bitbucket.(*Downloads).Create(0xc000810070, 0xc00041fa98, 0x7ffc3fa51285, 0x11, 0xc000888c30, 0xc00041fad8)
        /home/fabian/go/pkg/mod/github.com/ktrysmt/go-bitbucket@v0.6.5/downloads.go:9 +0x154
```

This should fix it.