### PR TITLE
Added support for pipelines endpoint

### DIFF
--- a/bitbucket.go
+++ b/bitbucket.go
@@ -91,6 +91,14 @@ type teams interface {
 	Projects(teamname string) (interface{}, error)
 }
 
+type pipelines interface {
+	List(po *PipelinesOptions) (interface{}, error)
+	Get(po *PipelinesOptions) (interface{}, error)
+	ListSteps(po *PipelinesOptions) (interface{}, error)
+	GetStep(po *PipelinesOptions) (interface{}, error)
+	GetLog(po *PipelinesOptions) (string, error)
+}
+
 type RepositoriesOptions struct {
 	Owner string `json:"owner"`
 	Role  string `json:"role"` // role=[owner|admin|contributor|member]
@@ -283,4 +291,13 @@ type PageRes struct {
 	PageLen  int32 `json:"pagelen"`
 	MaxDepth int32 `json:"max_depth"`
 	Size     int32 `json:"size"`
+}
+
+type PipelinesOptions struct {
+	Owner    string `json:"owner"`
+	RepoSlug string `json:"repo_slug"`
+	Query    string `json:"query"`
+	Sort     string `json:"sort"`
+	IDOrUuid string `json:"ID"`
+	StepUuid string `json:"StepUUID"`
 }

--- a/client.go
+++ b/client.go
@@ -129,6 +129,7 @@ func injectClient(a *auth) *Client {
 	c.Repositories = &Repositories{
 		c:                  c,
 		PullRequests:       &PullRequests{c: c},
+		Pipelines:          &Pipelines{c: c},
 		Repository:         &Repository{c: c},
 		Commits:            &Commits{c: c},
 		Diff:               &Diff{c: c},

--- a/pipelines.go
+++ b/pipelines.go
@@ -1,0 +1,92 @@
+package bitbucket
+
+import (
+	"io/ioutil"
+	"net/url"
+)
+
+type Pipelines struct {
+	c *Client
+}
+
+func (p *Pipelines) List(po *PipelinesOptions) (interface{}, error) {
+	urlStr := p.c.requestUrl("/repositories/%s/%s/pipelines/", po.Owner, po.RepoSlug)
+
+	if po.Query != "" {
+		parsed, err := url.Parse(urlStr)
+		if err != nil {
+			return nil, err
+		}
+		query := parsed.Query()
+		query.Set("q", po.Query)
+		parsed.RawQuery = query.Encode()
+		urlStr = parsed.String()
+	}
+
+	if po.Sort != "" {
+		parsed, err := url.Parse(urlStr)
+		if err != nil {
+			return nil, err
+		}
+		query := parsed.Query()
+		query.Set("sort", po.Sort)
+		parsed.RawQuery = query.Encode()
+		urlStr = parsed.String()
+	}
+
+	return p.c.execute("GET", urlStr, "")
+}
+
+func (p *Pipelines) Get(po *PipelinesOptions) (interface{}, error) {
+	urlStr := p.c.requestUrl("/repositories/%s/%s/pipelines/%s", po.Owner, po.RepoSlug, po.IDOrUuid)
+	return p.c.execute("GET", urlStr, "")
+}
+
+func (p *Pipelines) ListSteps(po *PipelinesOptions) (interface{}, error) {
+	urlStr := p.c.requestUrl("/repositories/%s/%s/pipelines/%s/steps/", po.Owner, po.RepoSlug, po.IDOrUuid)
+
+	if po.Query != "" {
+		parsed, err := url.Parse(urlStr)
+		if err != nil {
+			return nil, err
+		}
+		query := parsed.Query()
+		query.Set("q", po.Query)
+		parsed.RawQuery = query.Encode()
+		urlStr = parsed.String()
+	}
+
+	if po.Sort != "" {
+		parsed, err := url.Parse(urlStr)
+		if err != nil {
+			return nil, err
+		}
+		query := parsed.Query()
+		query.Set("sort", po.Sort)
+		parsed.RawQuery = query.Encode()
+		urlStr = parsed.String()
+	}
+
+	return p.c.execute("GET", urlStr, "")
+}
+
+func (p *Pipelines) GetStep(po *PipelinesOptions) (interface{}, error) {
+	urlStr := p.c.requestUrl("/repositories/%s/%s/pipelines/%s/steps/%s", po.Owner, po.RepoSlug, po.IDOrUuid, po.StepUuid)
+	return p.c.execute("GET", urlStr, "")
+}
+
+func (p *Pipelines) GetLog(po *PipelinesOptions) (string, error) {
+	urlStr := p.c.requestUrl("/repositories/%s/%s/pipelines/%s/steps/%s/log", po.Owner, po.RepoSlug, po.IDOrUuid, po.StepUuid)
+	responseBody, err := p.c.executeRaw("GET", urlStr, "")
+	if err != nil {
+		return "", err
+	}
+	defer responseBody.Close()
+
+	rawBody, err := ioutil.ReadAll(responseBody)
+	if err != nil {
+		return "", err
+	}
+
+	return string(rawBody), nil
+}

--- a/repositories.go
+++ b/repositories.go
@@ -11,6 +11,7 @@ import (
 type Repositories struct {
 	c                  *Client
 	PullRequests       *PullRequests
+	Pipelines          *Pipelines
 	Repository         *Repository
 	Commits            *Commits
 	Diff               *Diff


### PR DESCRIPTION
Hey there, @ktrysmt!

I required the various `pipelines`-endpoints available in bitbucket, so I therefore created them really quick.

The following endpoints are included:
- [pipelines/ (GET)](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/pipelines/); (POST) is currently not included, but I can add that, if you want to have it as well :)
- [pipelines/{pipeline_uuid} (GET)](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/pipelines/%7Bpipeline_uuid%7D)
- [pipelines/{pipeline_uuid}/steps/ (GET)](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/pipelines/%7Bpipeline_uuid%7D/steps/)
- [pipelines/{pipeline_uuid}/steps/{step_uuid} (GET)](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/pipelines/%7Bpipeline_uuid%7D/steps/%7Bstep_uuid%7D)
- [pipelines/{pipeline_uuid}/steps/{step_uuid}/log (GET)](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/pipelines/%7Bpipeline_uuid%7D/steps/%7Bstep_uuid%7D/log); This endpoint supports [range requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests) - would be cool to add this, since it would allow to see the logs of a file in real time without downloading the whole logs every time. Sounds awesome, if you ask me :) However, it would be required to add an header to the request, which `rawRequest` does not support currently. Do you mind if I add `rangeRequest` or something similar?