### PR TITLE
Added next parameter to pipelines

### DIFF
--- a/bitbucket.go
+++ b/bitbucket.go
@@ -295,6 +295,7 @@ type PageRes struct {
 
 type PipelinesOptions struct {
 	Owner    string `json:"owner"`
+	Page     int    `json:"page"`
 	RepoSlug string `json:"repo_slug"`
 	Query    string `json:"query"`
 	Sort     string `json:"sort"`

--- a/pipelines.go
+++ b/pipelines.go
@@ -1,6 +1,7 @@
 package bitbucket
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/url"
 )
@@ -34,6 +35,17 @@ func (p *Pipelines) List(po *PipelinesOptions) (interface{}, error) {
 		urlStr = parsed.String()
 	}
 
+	if po.Page != 0 {
+		parsed, err := url.Parse(urlStr)
+		if err != nil {
+			return nil, err
+		}
+		query := parsed.Query()
+		query.Set("page", fmt.Sprint(po.Page))
+		parsed.RawQuery = query.Encode()
+		urlStr = parsed.String()
+	}
+
 	return p.c.execute("GET", urlStr, "")
 }
 
@@ -63,6 +75,17 @@ func (p *Pipelines) ListSteps(po *PipelinesOptions) (interface{}, error) {
 		}
 		query := parsed.Query()
 		query.Set("sort", po.Sort)
+		parsed.RawQuery = query.Encode()
+		urlStr = parsed.String()
+	}
+
+	if po.Page != 0 {
+		parsed, err := url.Parse(urlStr)
+		if err != nil {
+			return nil, err
+		}
+		query := parsed.Query()
+		query.Set("page", fmt.Sprint(po.Page))
 		parsed.RawQuery = query.Encode()
 		urlStr = parsed.String()
 	}


### PR DESCRIPTION
Hey :)

I added https://github.com/ktrysmt/go-bitbucket/pull/106 a few days ago.

I assumed that the pipelines endpoint are paginated like the rest of the endpoints of bitbucket. But sadly, the list commands of the pipelines-endpoints don't provide a `next`-fields, so pagination must be manually.