### PR TITLE
Adds actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,15 @@ name: Continuous Integration
 
 on: push
 
+env:
+  BITBUCKET_TEST_USERNAME:  ${{ secrets.BITBUCKET_TEST_USERNAME }}
+  BITBUCKET_TEST_PASSWORD:  ${{ secrets.BITBUCKET_TEST_PASSWORD }}
+  BITBUCKET_TEST_OWNER:  ${{ secrets.BITBUCKET_TEST_OWNER }}
+  BITBUCKET_TEST_REPOSLUG:  ${{ secrets.BITBUCKET_TEST_REPOSLUG }}
+
 jobs:
-  test:
+  all-tests:
+    name: All Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -11,8 +18,26 @@ jobs:
         with:
           go-version: '1.15'
       - run: make test
-        env:
-          BITBUCKET_TEST_USERNAME:  ${{ secrets.BITBUCKET_TEST_USERNAME }}
-          BITBUCKET_TEST_PASSWORD:  ${{ secrets.BITBUCKET_TEST_PASSWORD }}
-          BITBUCKET_TEST_OWNER:  ${{ secrets.BITBUCKET_TEST_OWNER }}
-          BITBUCKET_TEST_REPOSLUG:  ${{ secrets.BITBUCKET_TEST_REPOSLUG }}
+
+  # This job is intended to only exist temporarily.
+  # To give greater visibility on which files are failing,
+  # while the errors with the tests are resolved
+  individual-tests:
+    name: Individual Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        file:
+          - branchrestrictions_test.go
+          - client_test.go
+          - diff_test.go
+          - list_test.go
+          - repository_test.go
+          - user_test.go
+          - workspace_test.go
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-go@v1
+        with:
+          go-version: '1.15'
+      - run: go test -v ./tests/${{ matrix.file }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: Continuous Integration
+
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-go@v1
+        with:
+          go-version: '1.15'
+      - run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
   # To give greater visibility on which files are failing,
   # while the errors with the tests are resolved
   individual-tests:
-    name: Run ${{ matrix.file }} (${{ matrix.os }}, ${{ matrix.go }})
+    name: ${{ matrix.file }} (${{ matrix.os }}, ${{ matrix.go }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false # When all tests are consistently passing this should be turned off

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,20 @@ env:
 jobs:
   all-tests:
     name: All Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+        go: [1.12, 1.13, 1.14, 1.15]
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-go@v1
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Setup Go ${{ matrix.go }}
+        uses: actions/setup-go@v1
         with:
-          go-version: '1.15'
-      - run: make test
+          go-version: ${{ matrix.go }}
+      - name: Run tests
+        run: make test
 
   # This job is intended to only exist temporarily.
   # To give greater visibility on which files are failing,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       fail-fast: false # When all tests are consistently passing this should be turned off
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
-        go: [1.12, 1.13, 1.14, 1.15]
+        os: [ macos-latest, windows-latest, ubuntu-latest ]
+        go: [ 1.14, 1.15 ]
     steps:
       - name: Checkout
         uses: actions/checkout@master
@@ -45,7 +45,7 @@ jobs:
           - user_test.go
           - workspace_test.go
         os: [ macos-latest, windows-latest, ubuntu-latest ]
-        go: [ 1.12, 1.13, 1.14, 1.15 ]
+        go: [ 1.14, 1.15 ]
     steps:
       - name: Checkout
         uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,3 +11,8 @@ jobs:
         with:
           go-version: '1.15'
       - run: make test
+        env:
+          BITBUCKET_TEST_USERNAME:  ${{ secrets.BITBUCKET_TEST_USERNAME }}
+          BITBUCKET_TEST_PASSWORD:  ${{ secrets.BITBUCKET_TEST_PASSWORD }}
+          BITBUCKET_TEST_OWNER:  ${{ secrets.BITBUCKET_TEST_OWNER }}
+          BITBUCKET_TEST_REPOSLUG:  ${{ secrets.BITBUCKET_TEST_REPOSLUG }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
   # To give greater visibility on which files are failing,
   # while the errors with the tests are resolved
   individual-tests:
-    name: Run ${{ matrix.file }}
+    name: Run ${{ matrix.file }} (${{ matrix.os }}, ${{ matrix.go }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false # When all tests are consistently passing this should be turned off

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,6 @@ jobs:
     strategy:
       fail-fast: false # When all tests are consistently passing this should be turned off
       matrix:
-        os: [ macos-latest, windows-latest, ubuntu-latest ]
-        go: [ 1.12, 1.13, 1.14, 1.15 ]
         file:
           - branchrestrictions_test.go
           - client_test.go
@@ -46,6 +44,8 @@ jobs:
           - repository_test.go
           - user_test.go
           - workspace_test.go
+        os: [ macos-latest, windows-latest, ubuntu-latest ]
+        go: [ 1.12, 1.13, 1.14, 1.15 ]
     steps:
       - name: Checkout
         uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     name: All Tests
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false # When all tests are consistently passing this should be turned off
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
         go: [1.12, 1.13, 1.14, 1.15]
@@ -33,6 +34,7 @@ jobs:
     name: Individual Tests
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false # When all tests are consistently passing this should be turned off
       matrix:
         file:
           - branchrestrictions_test.go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,13 @@ jobs:
   # To give greater visibility on which files are failing,
   # while the errors with the tests are resolved
   individual-tests:
-    name: Individual Tests
-    runs-on: ubuntu-latest
+    name: Run ${{ matrix.file }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false # When all tests are consistently passing this should be turned off
       matrix:
+        os: [ macos-latest, windows-latest, ubuntu-latest ]
+        go: [ 1.12, 1.13, 1.14, 1.15 ]
         file:
           - branchrestrictions_test.go
           - client_test.go
@@ -45,8 +47,11 @@ jobs:
           - user_test.go
           - workspace_test.go
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-go@v1
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Setup Go ${{ matrix.go }}
+        uses: actions/setup-go@v1
         with:
-          go-version: '1.15'
-      - run: go test -v ./tests/${{ matrix.file }}
+          go-version: ${{ matrix.go }}
+      - name: Run ${{ matrix.file }}
+        run: go test -v ./tests/${{ matrix.file }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 <a class="repo-badge" href="https://godoc.org/github.com/ktrysmt/go-bitbucket"><img src="https://godoc.org/github.com/ktrysmt/go-bitbucket?status.svg" alt="go-bitbucket?status"></a>
 <a href="https://goreportcard.com/report/github.com/ktrysmt/go-bitbucket"><img class="badge" tag="github.com/ktrysmt/go-bitbucket" src="https://goreportcard.com/badge/github.com/ktrysmt/go-bitbucket"></a>
+![Continuous Integration](https://github.com/ebh/go-bitbucket/workflows/Continuous%20Integration/badge.svg)
 
 > Bitbucket-API library for golang.
 


### PR DESCRIPTION
Note: I'm pretty new to continuous integration (CI) for Go modules. I saw a couple of different ways it could have been done but was unsure which was the best. So just picked one so I could raise a PR to start the discussion about what is the best way to proceed. So open to feedback :)

In #111 I raised the problem that tests were failing and suggested the idea of using GitHub Actions to run the tests.

This PR adds configuration to do that, run the tests using GitHub Actions to run the tests, not fix the tests that are failing.

The tests are run several times, once each for:
* Go versions: 1.12, 1.13, 1.14, 1.15
* OS: MacOS, Windows Ubuntu
* As a whole and each these file individually
   * Running the files individually is meant to temporarily only, while there are multiple problems with the tests failing

Because the tests need a Bitbucket (BB) account to run tests against I created a new BB account saved the details using [Github Actions Secrects](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets). This will need to be repeated in the Settings of the `ktrysmt/go-bitbucket`, which I don't have access to.