### PR TITLE
go.mod: bump go release to 1.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ktrysmt/go-bitbucket
 
-go 1.12
+go 1.14
 
 require (
 	github.com/golang/protobuf v1.0.0


### PR DESCRIPTION
Release 1.12 is no longer supported.

Signed-off-by: Kent R. Spillner <kspillner@acm.org>