### PR TITLE
add support for deleting pipeline variables

### DIFF
--- a/bitbucket.go
+++ b/bitbucket.go
@@ -36,6 +36,7 @@ type repository interface {
 	UpdatePipelineConfig(opt RepositoryPipelineOptions) (*Pipeline, error)
 	ListPipelineVariables(opt RepositoryPipelineVariablesOptions) (*PipelineVariables, error)
 	AddPipelineVariable(opt RepositoryPipelineVariableOptions) (*PipelineVariable, error)
+	DeletePipelineVariable(opt RepositoryPipelineVariableDeleteOptions) (interface{}, error)
 	AddPipelineKeyPair(opt RepositoryPipelineKeyPairOptions) (*PipelineKeyPair, error)
 	UpdatePipelineBuildNumber(opt RepositoryPipelineBuildNumberOptions) (*PipelineBuildNumber, error)
 	ListFiles(opt RepositoryFilesOptions) (*[]RepositoryFile, error)
@@ -270,6 +271,12 @@ type RepositoryPipelineVariableOptions struct {
 	Key      string `json:"key"`
 	Value    string `json:"value"`
 	Secured  bool   `json:"secured"`
+}
+
+type RepositoryPipelineVariableDeleteOptions struct {
+	Owner    string `json:"owner"`
+	RepoSlug string `json:"repo_slug"`
+	Uuid     string `json:"uuid"`
 }
 
 type RepositoryPipelineKeyPairOptions struct {

--- a/repository.go
+++ b/repository.go
@@ -388,6 +388,11 @@ func (r *Repository) AddPipelineVariable(rpvo *RepositoryPipelineVariableOptions
 	return decodePipelineVariableRepository(response)
 }
 
+func (r *Repository) DeletePipelineVariable(opt *RepositoryPipelineVariableDeleteOptions) (interface{}, error) {
+	urlStr := r.c.requestUrl("/repositories/%s/%s/pipelines_config/variables/%s", opt.Owner, opt.RepoSlug, opt.Uuid)
+	return r.c.execute("DELETE", urlStr, "")
+}
+
 func (r *Repository) AddPipelineKeyPair(rpkpo *RepositoryPipelineKeyPairOptions) (*PipelineKeyPair, error) {
 	data := r.buildPipelineKeyPairBody(rpkpo)
 	urlStr := r.c.requestUrl("/repositories/%s/%s/pipelines_config/ssh/key_pair", rpkpo.Owner, rpkpo.RepoSlug)

--- a/tests/repository_test.go
+++ b/tests/repository_test.go
@@ -81,3 +81,51 @@ func TestGetRepositoryPipelineVariables(t *testing.T) {
 		t.Error("Cannot list pipeline variables")
 	}
 }
+
+func TestDeleteRepositoryPipelineVariables(t *testing.T) {
+
+	user := os.Getenv("BITBUCKET_TEST_USERNAME")
+	pass := os.Getenv("BITBUCKET_TEST_PASSWORD")
+	owner := os.Getenv("BITBUCKET_TEST_OWNER")
+	repo := os.Getenv("BITBUCKET_TEST_REPOSLUG")
+
+	if user == "" {
+		t.Error("BITBUCKET_TEST_USERNAME is empty.")
+	}
+	if pass == "" {
+		t.Error("BITBUCKET_TEST_PASSWORD is empty.")
+	}
+	if owner == "" {
+		t.Error("BITBUCKET_TEST_OWNER is empty.")
+	}
+	if repo == "" {
+		t.Error("BITBUCKET_TEST_REPOSLUG is empty.")
+	}
+
+	c := bitbucket.NewBasicAuth(user, pass)
+
+	variable := &bitbucket.RepositoryPipelineVariableOptions{
+		Owner:    owner,
+		RepoSlug: repo,
+		Key:      "test_key_to_delete",
+		Value:    "Some value to delete",
+		Secured:  false,
+	}
+
+	res, err := c.Repositories.Repository.AddPipelineVariable(variable)
+	if err != nil {
+		t.Error(err)
+	}
+
+	opt := &bitbucket.RepositoryPipelineVariableDeleteOptions{
+		Owner:    owner,
+		RepoSlug: repo,
+		Uuid:     res.Uuid,
+	}
+
+	// On success the delete API doesn't return any content (HTTP status 204)
+	_, err = c.Repositories.Repository.DeletePipelineVariable(opt)
+	if err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
BitBucket's v2.0 API supports deleting pipeline variables by uuid.
On success, an empty response body with HTTP status 204 is returned.

Signed-off-by: Kent R. Spillner <kspillner@acm.org>