### PR TITLE
add initial support for environments

### DIFF
--- a/bitbucket.go
+++ b/bitbucket.go
@@ -43,6 +43,10 @@ type repository interface {
 	GetFileBlob(opt RepositoryBlobOptions) (*RepositoryBlob, error)
 	ListBranches(opt RepositoryBranchOptions) (*RepositoryBranches, error)
 	BranchingModel(opt RepositoryBranchingModelOptions) (*BranchingModel, error)
+	ListEnvironments(opt RepositoryEnvironmentsOptions) (*Environments, error)
+	AddEnvironment(opt RepositoryEnvironmentOptions) (*Environment, error)
+	DeleteEnvironment(opt RepositoryEnvironmentDeleteOptions) (interface{}, error)
+	GetEnvironment(opt RepositoryEnvironmentOptions) (*Environment, error)
 }
 
 type repositories interface {
@@ -319,4 +323,36 @@ type PipelinesOptions struct {
 	Sort     string `json:"sort"`
 	IDOrUuid string `json:"ID"`
 	StepUuid string `json:"StepUUID"`
+}
+
+type RepositoryEnvironmentsOptions struct {
+	Owner    string `json:"owner"`
+	RepoSlug string `json:"repo_slug"`
+}
+
+type RepositoryEnvironmentTypeOption int
+
+const (
+	Test RepositoryEnvironmentTypeOption = iota
+	Staging
+	Production
+)
+
+func (e RepositoryEnvironmentTypeOption) String() string {
+	return [...]string{"Test", "Staging", "Production"}[e]
+}
+
+type RepositoryEnvironmentOptions struct {
+	Owner           string `json:"owner"`
+	RepoSlug        string `json:"repo_slug"`
+	Uuid            string `json:"uuid"`
+	Name            string `json:"name"`
+	EnvironmentType RepositoryEnvironmentTypeOption `json:"environment_type"`
+	Rank            int `json:"rank"`
+}
+
+type RepositoryEnvironmentDeleteOptions struct {
+	Owner    string `json:"owner"`
+	RepoSlug string `json:"repo_slug"`
+	Uuid     string `json:"uuid"`
 }

--- a/tests/environment_test.go
+++ b/tests/environment_test.go
@@ -1,0 +1,109 @@
+package tests
+
+import (
+	"os"
+	"testing"
+
+	_ "github.com/k0kubun/pp"
+	"github.com/ktrysmt/go-bitbucket"
+)
+
+func TestListEnvironments(t *testing.T) {
+
+	user := os.Getenv("BITBUCKET_TEST_USERNAME")
+	pass := os.Getenv("BITBUCKET_TEST_PASSWORD")
+	owner := os.Getenv("BITBUCKET_TEST_OWNER")
+	repo := os.Getenv("BITBUCKET_TEST_REPOSLUG")
+
+	if user == "" {
+		t.Error("BITBUCKET_TEST_USERNAME is empty.")
+	}
+	if pass == "" {
+		t.Error("BITBUCKET_TEST_PASSWORD is empty.")
+	}
+	if owner == "" {
+		t.Error("BITBUCKET_TEST_OWNER is empty.")
+	}
+	if repo == "" {
+		t.Error("BITBUCKET_TEST_REPOSLUG is empty.")
+	}
+
+	c := bitbucket.NewBasicAuth(user, pass)
+
+	opt := &bitbucket.RepositoryEnvironmentsOptions{
+		Owner:    owner,
+		RepoSlug: repo,
+	}
+
+	res, err := c.Repositories.Repository.ListEnvironments(opt)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if res == nil {
+		t.Error("list didn't return any environments")
+	}
+}
+
+func TestEndToEndEnvironments(t *testing.T) {
+
+	user := os.Getenv("BITBUCKET_TEST_USERNAME")
+	pass := os.Getenv("BITBUCKET_TEST_PASSWORD")
+	owner := os.Getenv("BITBUCKET_TEST_OWNER")
+	repo := os.Getenv("BITBUCKET_TEST_REPOSLUG")
+
+	if user == "" {
+		t.Error("BITBUCKET_TEST_USERNAME is empty.")
+	}
+	if pass == "" {
+		t.Error("BITBUCKET_TEST_PASSWORD is empty.")
+	}
+	if owner == "" {
+		t.Error("BITBUCKET_TEST_OWNER is empty.")
+	}
+	if repo == "" {
+		t.Error("BITBUCKET_TEST_REPOSLUG is empty.")
+	}
+
+	c := bitbucket.NewBasicAuth(user, pass)
+
+	opt := &bitbucket.RepositoryEnvironmentOptions{
+		Owner:           owner,
+		RepoSlug:        repo,
+		Name:            "foo",
+		EnvironmentType: bitbucket.Test,
+	}
+
+	environment, err := c.Repositories.Repository.AddEnvironment(opt)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if environment.Uuid == "" {
+		t.Error("new environment does not have a UUID")
+	}
+
+	opt.Name = ""
+	opt.Uuid = environment.Uuid
+
+	foundEnvironment, err := c.Repositories.Repository.GetEnvironment(opt)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if foundEnvironment.Name != "foo" {
+		t.Errorf("got environment with wrong name: %s", foundEnvironment.Name)
+	}
+
+	deleteOpt := &bitbucket.RepositoryEnvironmentDeleteOptions{
+		Owner:    owner,
+		RepoSlug: repo,
+		Uuid:     environment.Uuid,
+	}
+
+	// On success the delete API doesn't return any content (HTTP status 204)
+	_, err = c.Repositories.Repository.DeleteEnvironment(deleteOpt)
+	if err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
Currently only supports listing, creating, getting, and deleting
environments.  Updating existing environments is also possible but
unfortunately the existing API documentation for the update endpoint is
incomplete, so I'm skipping it for now.

Documented at: https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/environments

Signed-off-by: Kent R. Spillner <kspillner@acm.org>