### PR TITLE
Adding repository pointer for parent to go-bitbucket

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -37,6 +37,7 @@ type Repository struct {
 	Type        string
 	Owner       map[string]interface{}
 	Links       map[string]interface{}
+	Parent      *Repository
 }
 
 type RepositoryFile struct {


### PR DESCRIPTION
The REST api for bitbucket optionally produces json that points to the parent of
a given repo (if it exists as a fork of another repo). It would be really
helpful to encode that information in the go api.  This patch does that

Signed-off-by: Neil horman <nhorman@tuxdriver.com>