### PR TITLE
Update return type of ListPublic()

### DIFF
--- a/repositories.go
+++ b/repositories.go
@@ -53,7 +53,7 @@ func (r *Repositories) ListForTeam(ro *RepositoriesOptions) (*RepositoriesRes, e
 	return decodeRepositorys(repos)
 }
 
-func (r *Repositories) ListPublic() (interface{}, error) {
+func (r *Repositories) ListPublic() (*RepositoriesRes, error) {
 	urlStr := r.c.requestUrl("/repositories/")
 	repos, err := r.c.execute("GET", urlStr, "")
 	if err != nil {


### PR DESCRIPTION
The return type of `ListPublic()` is `interface{}`, but should be the same as `ListForTeam(...)`.