### PR TITLE
Add git diff to resolve issue 142

### DIFF
--- a/bitbucket.go
+++ b/bitbucket.go
@@ -325,6 +325,19 @@ type DiffOptions struct {
 	Spec     string `json:"spec"`
 }
 
+type DiffStatOptions struct {
+	Owner      string `json:"owner"`
+	RepoSlug   string `json:"repo_slug"`
+	Spec       string `json:"spec"`
+	Whitespace bool   `json:"ignore_whitespace"`
+	Merge      bool   `json:"merge"`
+	Path       string `json:"path"`
+	Renames    bool   `json:"renames"`
+	PageNum    int    `json:"page"`
+	Pagelen    int    `json:"pagelen"`
+	MaxDepth   int    `json:"max_depth"`
+}
+
 type WebhooksOptions struct {
 	Owner       string   `json:"owner"`
 	RepoSlug    string   `json:"repo_slug"`

--- a/diff.go
+++ b/diff.go
@@ -1,7 +1,28 @@
 package bitbucket
 
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/url"
+	"strconv"
+
+	"github.com/mitchellh/mapstructure"
+)
+
 type Diff struct {
 	c *Client
+}
+
+type DiffStats struct {
+	Page     int
+	Pagelen  int
+	MaxDepth int
+	Size     int
+	Next     string
+	DiffStat []DiffStat
+}
+
+type DiffStat struct {
 }
 
 func (d *Diff) GetDiff(do *DiffOptions) (interface{}, error) {
@@ -12,4 +33,102 @@ func (d *Diff) GetDiff(do *DiffOptions) (interface{}, error) {
 func (d *Diff) GetPatch(do *DiffOptions) (interface{}, error) {
 	urlStr := d.c.requestUrl("/repositories/%s/%s/patch/%s", do.Owner, do.RepoSlug, do.Spec)
 	return d.c.executeRaw("GET", urlStr, "")
+}
+
+func (d *Diff) GetDiffStat(dso *DiffStatOptions) (interface{}, error) {
+
+	params := url.Values{}
+	if dso.Whitespace == true {
+		params.Add("ignore_whitespace", strconv.FormatBool(dso.Whitespace))
+	}
+
+	if dso.Merge == false {
+		params.Add("merge", strconv.FormatBool(dso.Merge))
+	}
+
+	if dso.Path != "" {
+		params.Add("path", dso.Path)
+	}
+
+	if dso.Renames == false {
+		params.Add("renames", strconv.FormatBool(dso.Renames))
+	}
+
+	if dso.PageNum > 0 {
+		params.Add("page", strconv.Itoa(dso.PageNum))
+	}
+
+	if dso.Pagelen > 0 {
+		params.Add("pagelen", strconv.Itoa(dso.Pagelen))
+	}
+
+	if dso.MaxDepth > 0 {
+		params.Add("max_depth", strconv.Itoa(dso.MaxDepth))
+	}
+
+	urlStr := d.c.requestUrl("/repositories/%s/%s/diffstat/%s?%s", dso.Owner, dso.RepoSlug,
+		dso.Spec,
+		params.Encode())
+	response, err := d.c.executeRaw("GET", urlStr, "")
+	if err != nil {
+		return nil, err
+	}
+	bodyBytes, err := ioutil.ReadAll(response)
+	if err != nil {
+		return nil, err
+	}
+	bodyString := string(bodyBytes)
+	return decodeDiffStat(bodyString)
+}
+
+func decodeDiffStat(diffStatResponseStr string) (*DiffStats, error) {
+
+	var diffStatResponseMap map[string]interface{}
+	err := json.Unmarshal([]byte(diffStatResponseStr), &diffStatResponseMap)
+	if err != nil {
+		return nil, err
+	}
+
+	diffStatArray := diffStatResponseMap["values"].([]interface{})
+	var diffStatsSlice []DiffStat
+	for _, diffStatEntry := range diffStatArray {
+		var diffStat DiffStat
+		err = mapstructure.Decode(diffStatEntry, &diffStat)
+		if err == nil {
+			diffStatsSlice = append(diffStatsSlice, diffStat)
+		}
+	}
+
+	page, ok := diffStatResponseMap["page"].(float64)
+	if !ok {
+		page = 0
+	}
+
+	pagelen, ok := diffStatResponseMap["pagelen"].(float64)
+	if !ok {
+		pagelen = 0
+	}
+	max_depth, ok := diffStatResponseMap["max_depth"].(float64)
+	if !ok {
+		max_depth = 0
+	}
+	size, ok := diffStatResponseMap["size"].(float64)
+	if !ok {
+		size = 0
+	}
+
+	next, ok := diffStatResponseMap["next"].(string)
+	if !ok {
+		next = ""
+	}
+
+	diffStats := DiffStats{
+		Page:     int(page),
+		Pagelen:  int(pagelen),
+		MaxDepth: int(max_depth),
+		Size:     int(size),
+		Next:     next,
+		DiffStat: diffStatsSlice,
+	}
+	return &diffStats, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ktrysmt/go-bitbucket
 go 1.14
 
 require (
-	github.com/golang/protobuf v1.0.0
+	github.com/golang/protobuf v1.0.0 // indirect
 	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
 	github.com/k0kubun/pp v2.3.0+incompatible
 	github.com/mattn/go-colorable v0.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,7 @@ golang.org/x/sys v0.0.0-20180224232135-f6cff0780e54 h1:4qAtdeqGYyXU2CfUvLomEFw0c
 golang.org/x/sys v0.0.0-20180224232135-f6cff0780e54/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 google.golang.org/appengine v1.0.0 h1:dN4LljjBKVChsv0XCSI+zbyzdqrkEwX5LQFUMRSGqOc=
 google.golang.org/appengine v1.0.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tests/diff_test.go
+++ b/tests/diff_test.go
@@ -43,3 +43,37 @@ func TestDiff(t *testing.T) {
 		t.Error("It could not get the raw response.")
 	}
 }
+
+func TestGetDiffStat(t *testing.T) {
+
+	user := os.Getenv("BITBUCKET_TEST_USERNAME")
+	pass := os.Getenv("BITBUCKET_TEST_PASSWORD")
+	owner := os.Getenv("BITBUCKET_TEST_OWNER")
+	repo := os.Getenv("BITBUCKET_TEST_REPOSLUG")
+
+	if user == "" {
+		t.Error("BITBUCKET_TEST_USERNAME is empty.")
+	}
+
+	if pass == "" {
+		t.Error("BITBUCKET_TEST_PASSWORD is empty.")
+	}
+
+	c := bitbucket.NewBasicAuth(user, pass)
+
+	spec := "master..develop"
+
+	opt := &bitbucket.DiffStatOptions{
+		Owner:    owner,
+		RepoSlug: repo,
+		Spec:     spec,
+	}
+	res, err := c.Repositories.Diff.GetDiffStat(opt)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if res == nil {
+		t.Error("Cannot get diffstat.")
+	}
+}

--- a/tests/diff_test.go
+++ b/tests/diff_test.go
@@ -73,6 +73,8 @@ func TestGetDiffStat(t *testing.T) {
 		t.Error(err)
 	}
 
+	pp.Println(res)
+
 	if res == nil {
 		t.Error("Cannot get diffstat.")
 	}


### PR DESCRIPTION
This PR creates the GetDiffStat function as well as its corresponding test. 

The new function currently just returns the DiffStatRes object that includes the DiffStats object which is a slice of DiffStat's. The DiffStats are the "values" returned by the Bitbucket 2.0 API.

@ktrysmt my tests pass successfully, but for some reason I couldn't get the Docker/Swagger tests to pass; it kept saying the Bitbucket env variables were empty. If this is resolved I can rerun this part of the test.

FYI: in I had to tweak the `TestCreateBranchRestrictionsKindPush` and `TestCreateBranchRestrictionsKindRequirePassingBuilds` tests in order to get the test suite build to run the diff tests. The tweaks I made will be in another PR that I will submit soon.

Thank you for letting me contribute to this wonderful go package. I hope to contribute even more!!!!