### PR TITLE
Add tests for branch permission deletion

### DIFF
--- a/tests/branchrestrictions_test.go
+++ b/tests/branchrestrictions_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/ktrysmt/go-bitbucket"
@@ -33,50 +34,74 @@ func setup(t *testing.T) *bitbucket.Client {
 	return c
 }
 
-func TestCreateBranchRestrictionsKindPush(t *testing.T) {
+func TestBranchRestrictionsKindPush(t *testing.T) {
 
 	c := setup(t)
+	var pushRestrictionID int
 
-	opt := &bitbucket.BranchRestrictionsOptions{
-		Owner:    owner,
-		Pattern:  "develop",
-		RepoSlug: repo,
-		Kind:     "push",
-		Users:    []string{user},
-	}
-	res, err := c.Repositories.BranchRestrictions.Create(opt)
-	if err != nil {
-		t.Error(err)
-	}
-	jsonMap := res.(map[string]interface{})
-	if jsonMap["type"] != "branchrestriction" {
-		t.Error("is not branchrestriction type")
-	}
-	if jsonMap["kind"] != "push" {
-		t.Error("did not match branchrestriction kind")
-	}
+	t.Run("create", func(t *testing.T) {
+		opt := &bitbucket.BranchRestrictionsOptions{
+			Owner:    owner,
+			Pattern:  "develop",
+			RepoSlug: repo,
+			Kind:     "push",
+			Users:    []string{user},
+		}
+		res, err := c.Repositories.BranchRestrictions.Create(opt)
+		if err != nil {
+			t.Error(err)
+		}
+		if res.Kind != "push" {
+			t.Error("did not match branchrestriction kind")
+		}
+		pushRestrictionID = res.ID
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		opt := &bitbucket.BranchRestrictionsOptions{
+			Owner:    owner,
+			RepoSlug: repo,
+			ID:       strconv.Itoa(pushRestrictionID),
+		}
+		_, err := c.Repositories.BranchRestrictions.Delete(opt)
+		if err != nil {
+			t.Error(err)
+		}
+	})
 }
 
-func TestCreateBranchRestrictionsKindRequirePassingBuilds(t *testing.T) {
+func TestBranchRestrictionsKindRequirePassingBuilds(t *testing.T) {
 
 	c := setup(t)
+	var pushRestrictionID int
 
-	opt := &bitbucket.BranchRestrictionsOptions{
-		Owner:    owner,
-		Pattern:  "master",
-		RepoSlug: repo,
-		Kind:     "require_passing_builds_to_merge",
-		Value:    2,
-	}
-	res, err := c.Repositories.BranchRestrictions.Create(opt)
-	if err != nil {
-		t.Error(err)
-	}
-	jsonMap := res.(map[string]interface{})
-	if jsonMap["type"] != "branchrestriction" {
-		t.Error("is not branchrestriction type")
-	}
-	if jsonMap["kind"] != "require_passing_builds_to_merge" {
-		t.Error("did not match branchrestriction kind")
-	}
+	t.Run("create", func(t *testing.T) {
+		opt := &bitbucket.BranchRestrictionsOptions{
+			Owner:    owner,
+			Pattern:  "master",
+			RepoSlug: repo,
+			Kind:     "require_passing_builds_to_merge",
+			Value:    2,
+		}
+		res, err := c.Repositories.BranchRestrictions.Create(opt)
+		if err != nil {
+			t.Error(err)
+		}
+		if res.Kind != "require_passing_builds_to_merge" {
+			t.Error("did not match branchrestriction kind")
+		}
+		pushRestrictionID = res.ID
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		opt := &bitbucket.BranchRestrictionsOptions{
+			Owner:    owner,
+			RepoSlug: repo,
+			ID:       strconv.Itoa(pushRestrictionID),
+		}
+		_, err := c.Repositories.BranchRestrictions.Delete(opt)
+		if err != nil {
+			t.Error(err)
+		}
+	})
 }


### PR DESCRIPTION
This PR allows one to eventually run the test suite repeatedly without manually intervening in the Bitbucket UI to clean up branch permission test resources.