### PR TITLE
Create RepositoryRefsOptions and ListRefs method with helper funds

### DIFF
--- a/bitbucket.go
+++ b/bitbucket.go
@@ -199,6 +199,21 @@ type RepositoryBlobWriteOptions struct {
 	Branch   string `json:"branch"`
 }
 
+// RepositoryRefOptions represents the options for describing a repository's refs (i.e.
+// tags and branches). The field BranchFlg is a boolean that is indicates whether a specific
+// RepositoryRefOptions instance is meant for Branch specific set of api methods.
+type RepositoryRefOptions struct {
+	Owner     string `json:"owner"`
+	RepoSlug  string `json:"repo_slug"`
+	Query     string `json:"query"`
+	Sort      string `json:"sort"`
+	PageNum   int    `json:"page"`
+	Pagelen   int    `json:"pagelen"`
+	MaxDepth  int    `json:"max_depth"`
+	Name      string `json:"name"`
+	BranchFlg bool
+}
+
 type RepositoryBranchOptions struct {
 	Owner      string `json:"owner"`
 	RepoSlug   string `json:"repo_slug"`

--- a/repository.go
+++ b/repository.go
@@ -287,7 +287,9 @@ func (r *Repository) WriteFileBlob(ro *RepositoryBlobWriteOptions) error {
 	return err
 }
 
-func (r *Repository) ListRefs(rbo *RepositoryBranchOptions) (*RepositoryRefs, error) {
+// ListRefs gets all refs in the Bitbucket repository and returns them as a RepositoryRefs.
+// It takes in a RepositoryRefOptions instance as its only parameter.
+func (r *Repository) ListRefs(rbo *RepositoryRefOptions) (*RepositoryRefs, error) {
 
 	params := url.Values{}
 	if rbo.Query != "" {

--- a/tests/repository_test.go
+++ b/tests/repository_test.go
@@ -129,3 +129,74 @@ func TestDeleteRepositoryPipelineVariables(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestGetRepositoryRefs(t *testing.T) {
+
+	user := os.Getenv("BITBUCKET_TEST_USERNAME")
+	pass := os.Getenv("BITBUCKET_TEST_PASSWORD")
+	owner := os.Getenv("BITBUCKET_TEST_OWNER")
+	repo := os.Getenv("BITBUCKET_TEST_REPOSLUG")
+
+	if user == "" {
+		t.Error("BITBUCKET_TEST_USERNAME is empty.")
+	}
+	if pass == "" {
+		t.Error("BITBUCKET_TEST_PASSWORD is empty.")
+	}
+	if owner == "" {
+		t.Error("BITBUCKET_TEST_OWNER is empty.")
+	}
+	if repo == "" {
+		t.Error("BITBUCKET_TEST_REPOSLUG is empty.")
+	}
+
+	c := bitbucket.NewBasicAuth(user, pass)
+
+	opt := &bitbucket.RepositoryBranchCreationOptions{
+		Owner:    owner,
+		RepoSlug: repo,
+		Name:     "TestGetRepoRefsBranch",
+		Target:   bitbucket.RepositoryBranchTarget{Hash: "master"},
+	}
+
+	_, err := c.Repositories.Repository.CreateBranch(opt)
+	if err != nil {
+		t.Error("Could not create new branch", err)
+	}
+
+	refOpts := &bitbucket.RepositoryRefOptions{
+		Owner:    owner,
+		RepoSlug: repo,
+	}
+
+	resRefs, err := c.Repositories.Repository.ListRefs(refOpts)
+	if err != nil {
+		t.Error("The refs is not found.")
+	}
+
+	expected := struct {
+		n string
+		t string
+	}{}
+
+	for _, ref := range resRefs.Refs {
+		for k, v := range ref {
+			// kCopy := k
+			vCopy := v
+			if val, ok := vCopy.(string); ok {
+				if k == "name" && val == "TestGetRepoRefsBranch" {
+					expected.n = val
+				}
+			}
+			if val, ok := vCopy.(string); ok {
+				if k == "type" && val == "branch" {
+					expected.t = val
+				}
+			}
+		}
+	}
+
+	if !(expected.n == "TestGetRepoRefsBranch" && expected.t == "branch") {
+		t.Error("Could not list refs/branch that was created in test setup")
+	}
+}


### PR DESCRIPTION
TL;DR: this PR creates a RepositoryRefsOptions type and starts the groundwork to eventually remove RepositoryBranchOptions and RepositoryTagOptions and those methods that relies on these types. 

This PR creates a RepositoryRefsOptions and a ListRefs method on the Repository type. This new refs type will allow users to specific their refs options once and be able to operate on all kinds of refs (i.e. tags and branches) without specifying 2 separate options. Right now, users have to specify a RepositoryBranchOptions and RepositoryTagOptions in order to call ListBranches and ListTags. 

This current iteration of the code doesn't adhere to the fact that git refers to all branches and tags as refs and this is reflected in the Bitbucket API since both tags and branches endpoints are build off of the refs endpoint. 

I want to add a test for this new ListRefs function, but in the meantime I wanted to create this PR s that we could discuss future plans. Currently, I think it is best to keep Refs options alongside the branches and tags options since if we remove those 2 option types then it imparts a breaking change on users. So we should slowly move towards removing those option types and their methods instead removing support all at once and making a bunch of breaking changes.

Once we have built out the same functionality for branches and tags build upon the refs options type then we can move to completely remove the branches and tags options types and release for a breaking change.
