### PR TITLE
Ddansby/issue 154 add delete branch and tag methods

### DIFF
--- a/bitbucket.go
+++ b/bitbucket.go
@@ -215,14 +215,14 @@ type RepositoryRefOptions struct {
 }
 
 type RepositoryBranchOptions struct {
-	Owner      string `json:"owner"`
-	RepoSlug   string `json:"repo_slug"`
-	Query      string `json:"query"`
-	Sort       string `json:"sort"`
-	PageNum    int    `json:"page"`
-	Pagelen    int    `json:"pagelen"`
-	MaxDepth   int    `json:"max_depth"`
-	BranchName string `json:"branch_name"`
+	Owner    string `json:"owner"`
+	RepoSlug string `json:"repo_slug"`
+	Query    string `json:"query"`
+	Sort     string `json:"sort"`
+	PageNum  int    `json:"page"`
+	Pagelen  int    `json:"pagelen"`
+	MaxDepth int    `json:"max_depth"`
+	Name     string `json:"name"`
 }
 
 type RepositoryBranchCreationOptions struct {
@@ -252,6 +252,7 @@ type RepositoryTagOptions struct {
 	PageNum  int    `json:"page"`
 	Pagelen  int    `json:"pagelen"`
 	MaxDepth int    `json:"max_depth"`
+	Name     string `json:"name"`
 }
 
 type RepositoryTagCreationOptions struct {

--- a/bitbucket.go
+++ b/bitbucket.go
@@ -214,6 +214,10 @@ type RepositoryRefOptions struct {
 	BranchFlg bool
 }
 
+type RepositoryRefTarget struct {
+	Hash string `json:"hash"`
+}
+
 type RepositoryBranchOptions struct {
 	Owner    string `json:"owner"`
 	RepoSlug string `json:"repo_slug"`
@@ -226,22 +230,10 @@ type RepositoryBranchOptions struct {
 }
 
 type RepositoryBranchCreationOptions struct {
-	Owner    string                 `json:"owner"`
-	RepoSlug string                 `json:"repo_slug"`
-	Name     string                 `json:"name"`
-	Target   RepositoryBranchTarget `json:"target"`
-}
-
-type RepositoryBranchDeleteOptions struct {
-	Owner    string `json:"owner"`
-	RepoSlug string `json:"repo_slug"`
-	RepoUUID string `json:"uuid"`
-	RefName  string `json:"name"`
-	RefUUID  string `json:uuid`
-}
-
-type RepositoryBranchTarget struct {
-	Hash string `json:"hash"`
+	Owner    string              `json:"owner"`
+	RepoSlug string              `json:"repo_slug"`
+	Name     string              `json:"name"`
+	Target   RepositoryRefTarget `json:"target"`
 }
 
 type RepositoryTagOptions struct {
@@ -259,11 +251,7 @@ type RepositoryTagCreationOptions struct {
 	Owner    string              `json:"owner"`
 	RepoSlug string              `json:"repo_slug"`
 	Name     string              `json:"name"`
-	Target   RepositoryTagTarget `json:"target"`
-}
-
-type RepositoryTagTarget struct {
-	Hash string `json:"hash"`
+	Target   RepositoryRefTarget `json:"target"`
 }
 
 type PullRequestsOptions struct {

--- a/repository.go
+++ b/repository.go
@@ -366,10 +366,10 @@ func (r *Repository) ListBranches(rbo *RepositoryBranchOptions) (*RepositoryBran
 }
 
 func (r *Repository) GetBranch(rbo *RepositoryBranchOptions) (*RepositoryBranch, error) {
-	if rbo.BranchName == "" {
+	if rbo.Name == "" {
 		return nil, errors.New("Error: Branch Name is empty")
 	}
-	urlStr := r.c.requestUrl("/repositories/%s/%s/refs/branches/%s", rbo.Owner, rbo.RepoSlug, rbo.BranchName)
+	urlStr := r.c.requestUrl("/repositories/%s/%s/refs/branches/%s", rbo.Owner, rbo.RepoSlug, rbo.Name)
 	response, err := r.c.executeRaw("GET", urlStr, "")
 	if err != nil {
 		return nil, err
@@ -380,21 +380,6 @@ func (r *Repository) GetBranch(rbo *RepositoryBranchOptions) (*RepositoryBranch,
 	}
 	bodyString := string(bodyBytes)
 	return decodeRepositoryBranch(bodyString)
-}
-
-// DeleteBranch https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/refs/branches/%7Bname%7D#delete
-func (r *Repository) DeleteBranch(rbo *RepositoryBranchDeleteOptions) error {
-	repo := rbo.RepoSlug
-	if rbo.RepoUUID != "" {
-		repo = rbo.RepoUUID
-	}
-	ref := rbo.RefName
-	if rbo.RefUUID != "" {
-		ref = rbo.RefUUID
-	}
-	urlStr := r.c.requestUrl("/repositories/%s/%s/refs/branches/%s", rbo.Owner, repo, ref)
-	_, err := r.c.execute("DELETE", urlStr, "")
-	return err
 }
 
 func (r *Repository) CreateBranch(rbo *RepositoryBranchCreationOptions) (*RepositoryBranch, error) {
@@ -418,30 +403,36 @@ func (r *Repository) CreateBranch(rbo *RepositoryBranchCreationOptions) (*Reposi
 	return decodeRepositoryBranchCreated(bodyString)
 }
 
-func (r *Repository) ListTags(rbo *RepositoryTagOptions) (*RepositoryTags, error) {
+func (r *Repository) DeleteBranch(rbo *RepositoryBranchOptions) (interface{}, error) {
+	urlStr := r.c.requestUrl("/repositories/%s/%s/refs/branches/%s", rbo.Owner, rbo.RepoSlug,
+		rbo.Name)
+	return r.c.execute("DELETE", urlStr, "")
+}
+
+func (r *Repository) ListTags(rto *RepositoryTagOptions) (*RepositoryTags, error) {
 
 	params := url.Values{}
-	if rbo.Query != "" {
-		params.Add("q", rbo.Query)
+	if rto.Query != "" {
+		params.Add("q", rto.Query)
 	}
 
-	if rbo.Sort != "" {
-		params.Add("sort", rbo.Sort)
+	if rto.Sort != "" {
+		params.Add("sort", rto.Sort)
 	}
 
-	if rbo.PageNum > 0 {
-		params.Add("page", strconv.Itoa(rbo.PageNum))
+	if rto.PageNum > 0 {
+		params.Add("page", strconv.Itoa(rto.PageNum))
 	}
 
-	if rbo.Pagelen > 0 {
-		params.Add("pagelen", strconv.Itoa(rbo.Pagelen))
+	if rto.Pagelen > 0 {
+		params.Add("pagelen", strconv.Itoa(rto.Pagelen))
 	}
 
-	if rbo.MaxDepth > 0 {
-		params.Add("max_depth", strconv.Itoa(rbo.MaxDepth))
+	if rto.MaxDepth > 0 {
+		params.Add("max_depth", strconv.Itoa(rto.MaxDepth))
 	}
 
-	urlStr := r.c.requestUrl("/repositories/%s/%s/refs/tags?%s", rbo.Owner, rbo.RepoSlug, params.Encode())
+	urlStr := r.c.requestUrl("/repositories/%s/%s/refs/tags?%s", rto.Owner, rto.RepoSlug, params.Encode())
 	response, err := r.c.executeRaw("GET", urlStr, "")
 	if err != nil {
 		return nil, err
@@ -454,9 +445,9 @@ func (r *Repository) ListTags(rbo *RepositoryTagOptions) (*RepositoryTags, error
 	return decodeRepositoryTags(bodyString)
 }
 
-func (r *Repository) CreateTag(rbo *RepositoryTagCreationOptions) (*RepositoryTag, error) {
-	urlStr := r.c.requestUrl("/repositories/%s/%s/refs/tags", rbo.Owner, rbo.RepoSlug)
-	data, err := r.buildTagBody(rbo)
+func (r *Repository) CreateTag(rto *RepositoryTagCreationOptions) (*RepositoryTag, error) {
+	urlStr := r.c.requestUrl("/repositories/%s/%s/refs/tags", rto.Owner, rto.RepoSlug)
+	data, err := r.buildTagBody(rto)
 	if err != nil {
 		return nil, err
 	}
@@ -473,6 +464,12 @@ func (r *Repository) CreateTag(rbo *RepositoryTagCreationOptions) (*RepositoryTa
 
 	bodyString := string(bodyBytes)
 	return decodeRepositoryTagCreated(bodyString)
+}
+
+func (r *Repository) DeleteTag(rto *RepositoryTagOptions) (interface{}, error) {
+	urlStr := r.c.requestUrl("/repositories/%s/%s/refs/tags/%s", rto.Owner, rto.RepoSlug,
+		rto.Name)
+	return r.c.execute("DELETE", urlStr, "")
 }
 
 func (r *Repository) Update(ro *RepositoryOptions) (*Repository, error) {

--- a/tests/repository_test.go
+++ b/tests/repository_test.go
@@ -274,8 +274,10 @@ func TestDeleteRepositoryPipelineVariables(t *testing.T) {
 	}
 }
 
+// This test tests the CreateBranch, CreateTag, ListRefs, DeleteBranch, and DeleteTag repo methods
 func TestGetRepositoryRefs(t *testing.T) {
-
+	// Create Branch, List Refs and search for Branch that was created,
+	// then test successful Branch deletion
 	user := os.Getenv("BITBUCKET_TEST_USERNAME")
 	pass := os.Getenv("BITBUCKET_TEST_PASSWORD")
 	owner := os.Getenv("BITBUCKET_TEST_OWNER")
@@ -300,7 +302,7 @@ func TestGetRepositoryRefs(t *testing.T) {
 		Owner:    owner,
 		RepoSlug: repo,
 		Name:     "TestGetRepoRefsBranch",
-		Target:   bitbucket.RepositoryBranchTarget{Hash: "master"},
+		Target:   bitbucket.RepositoryRefTarget{Hash: "master"},
 	}
 
 	_, err := c.Repositories.Repository.CreateBranch(opt)
@@ -308,39 +310,127 @@ func TestGetRepositoryRefs(t *testing.T) {
 		t.Error("Could not create new branch", err)
 	}
 
-	refOpts := &bitbucket.RepositoryRefOptions{
+	refBranchOpts := &bitbucket.RepositoryRefOptions{
 		Owner:    owner,
 		RepoSlug: repo,
 	}
 
-	resRefs, err := c.Repositories.Repository.ListRefs(refOpts)
+	resBranchRefs, err := c.Repositories.Repository.ListRefs(refBranchOpts)
 	if err != nil {
-		t.Error("The refs is not found.")
+		t.Error("The refs/branch is not found.")
 	}
 
-	expected := struct {
+	branchExpected := struct {
 		n string
 		t string
 	}{}
 
-	for _, ref := range resRefs.Refs {
+	for _, ref := range resBranchRefs.Refs {
 		for k, v := range ref {
 			// kCopy := k
 			vCopy := v
 			if val, ok := vCopy.(string); ok {
 				if k == "name" && val == "TestGetRepoRefsBranch" {
-					expected.n = val
+					branchExpected.n = val
 				}
 			}
 			if val, ok := vCopy.(string); ok {
 				if k == "type" && val == "branch" {
-					expected.t = val
+					branchExpected.t = val
 				}
 			}
 		}
 	}
 
-	if !(expected.n == "TestGetRepoRefsBranch" && expected.t == "branch") {
+	if !(branchExpected.n == "TestGetRepoRefsBranch" && branchExpected.t == "branch") {
 		t.Error("Could not list refs/branch that was created in test setup")
+	}
+
+	delBranchOpt := &bitbucket.RepositoryBranchOptions{
+		Owner:    owner,
+		RepoSlug: repo,
+		Name:     "TestGetRepoRefsBranch",
+	}
+	resBranchDel, err := c.Repositories.Repository.DeleteBranch(delBranchOpt)
+	if err != nil {
+		t.Error("Could not delete branch")
+	}
+
+	if mp, ok := resBranchDel.(map[string]interface{}); ok {
+		for k, v := range mp {
+			if k == "type" && v == "error" {
+				t.Error("Delete branch returned an error, when it should have successfully" +
+					"delete the test branch created during test setup")
+			}
+		}
+	}
+
+	// Create Tag, List Refs and search for Tag that was created,
+	// then test successful Tag deletion
+	tagOpt := &bitbucket.RepositoryTagCreationOptions{
+		Owner:    owner,
+		RepoSlug: repo,
+		Name:     "TestGetRepoRefsTag",
+		Target:   bitbucket.RepositoryRefTarget{Hash: "master"},
+	}
+
+	_, err = c.Repositories.Repository.CreateTag(tagOpt)
+	if err != nil {
+		t.Error("Could not create new tag", err)
+	}
+
+	refTagOpts := &bitbucket.RepositoryRefOptions{
+		Owner:    owner,
+		RepoSlug: repo,
+	}
+
+	resTagRefs, err := c.Repositories.Repository.ListRefs(refTagOpts)
+	if err != nil {
+		t.Error("The ref/tag is not found.")
+	}
+
+	tagExpected := struct {
+		n string
+		t string
+	}{}
+
+	for _, ref := range resTagRefs.Refs {
+		for k, v := range ref {
+			// kCopy := k
+			vCopy := v
+			if val, ok := vCopy.(string); ok {
+				if k == "name" && val == "TestGetRepoRefsTag" {
+					tagExpected.n = val
+				}
+			}
+			if val, ok := vCopy.(string); ok {
+				if k == "type" && val == "tag" {
+					tagExpected.t = val
+				}
+			}
+		}
+	}
+
+	if !(tagExpected.n == "TestGetRepoRefsTag" && tagExpected.t == "tag") {
+		t.Error("Could not list refs/tag that was created in test setup")
+	}
+
+	delTagOpt := &bitbucket.RepositoryTagOptions{
+		Owner:    owner,
+		RepoSlug: repo,
+		Name:     "TestGetRepoRefsTag",
+	}
+	resTagDel, err := c.Repositories.Repository.DeleteTag(delTagOpt)
+	if err != nil {
+		t.Error("Could not delete tag")
+	}
+
+	if mp, ok := resTagDel.(map[string]interface{}); ok {
+		for k, v := range mp {
+			if k == "type" && v == "error" {
+				t.Error("Delete tag returned an error, when it should have successfully" +
+					"delete the test tag created during test setup")
+			}
+		}
 	}
 }


### PR DESCRIPTION
This PR closes #154. It specifically adds the DeleteBranch and DeleteTag methods.

**_Note this PR should not be merged until https://github.com/ktrysmt/go-bitbucket/pull/155 is merged since it uses the code from that PR for its tests._**

It also works towards removing branch and tag specific options and moving to a single refs options (see https://github.com/ktrysmt/go-bitbucket/issues/153). Furthermore This test also improves the ListRefs tests from https://github.com/ktrysmt/go-bitbucket/pull/155 by adding a part that tests the creation of a Tag and then also tests the new DeleteBranch and DeleteTag methods as they are used in the tear down of the ListRefs tests (they are used to delete the test tag/branch).

I believe this is good to be approved/merged, but I am interested to hear opinions about how I currently handle errors/responses from DELETE http methods. Currently, the Bitbucket API returns an error json/map[string]interface{} type if there is an error and returns and 204 response code if the DELETE is successful. 

Currently, in this PR I just processed and returned interface{} similarly to the Delete method for the repository type itself. Do you think we should leave it to the user to handle error responses? Or should I try to handle it more gracefully? Should I worry about providing more intuitive success responses; or just leave it as a typical delete method in that only return a response if there is an issue? Currently, for testing, I search that the response doesn't include the error type which is indicative that there was an issue deleting a branch/tag for any of the reasons specified in the documentation (for example https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/refs/tags/%7Bname%7D#delete)