### PR TITLE
Fix bug with `Project` struct

### DIFF
--- a/project.go
+++ b/project.go
@@ -15,7 +15,7 @@ type Project struct {
 	Key         string
 	Name        string
 	Description string
-	IsPrivate   bool
+	Is_private  bool
 }
 
 type ProjectOptions struct {

--- a/tests/project_test.go
+++ b/tests/project_test.go
@@ -1,0 +1,98 @@
+package tests
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ktrysmt/go-bitbucket"
+)
+
+func getClient(t *testing.T) *bitbucket.Client {
+	user := os.Getenv("BITBUCKET_TEST_USERNAME")
+	pass := os.Getenv("BITBUCKET_TEST_PASSWORD")
+
+	if user == "" {
+		t.Error("BITBUCKET_TEST_USERNAME is empty.")
+	}
+	if pass == "" {
+		t.Error("BITBUCKET_TEST_PASSWORD is empty.")
+	}
+
+	return bitbucket.NewBasicAuth(user, pass)
+}
+
+func getOwner(t *testing.T) string {
+	owner := os.Getenv("BITBUCKET_TEST_OWNER")
+
+	if owner == "" {
+		t.Error("BITBUCKET_TEST_OWNER is empty.")
+	}
+
+	return owner
+}
+
+func TestProjectCreate_isPrivateTrue(t *testing.T) {
+	c := getClient(t)
+
+	projectName := "go-bitbucket-test-project-create-is-private-true"
+	projectKey := "GO_BB_TEST_PROJ_CR_IS_PRIV_TRUE"
+	opt := &bitbucket.ProjectOptions{
+		Owner:     getOwner(t),
+		Name:      projectName,
+		Key:       projectKey,
+		IsPrivate: true,
+	}
+	project, err := c.Workspaces.CreateProject(opt)
+	if err != nil {
+		t.Error("The project could not be created.")
+	}
+
+	if project.Name != projectName {
+		t.Error("The project `Name` attribute does not match the expected value.")
+	}
+	if project.Key != projectKey {
+		t.Error("The project `Key` attribute does not match the expected value.")
+	}
+	if project.Is_private != true {
+		t.Error("The project `Is_private` attribute does not match the expected value.")
+	}
+
+	// Delete the project, so we can keep a clean test environment
+	_, err = c.Workspaces.DeleteProject(opt)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestProjectCreate_isPrivateFalse(t *testing.T) {
+	c := getClient(t)
+
+	projectName := "go-bitbucket-test-project-create-is-private-false"
+	projectKey := "GO_BB_TEST_PROJ_CR_IS_PRIV_FALSE"
+	opt := &bitbucket.ProjectOptions{
+		Owner:     getOwner(t),
+		Name:      projectName,
+		Key:       projectKey,
+		IsPrivate: false,
+	}
+	project, err := c.Workspaces.CreateProject(opt)
+	if err != nil {
+		t.Error("The project could not be created.")
+	}
+
+	if project.Name != projectName {
+		t.Error("The project `Name` attribute does not match the expected value.")
+	}
+	if project.Key != projectKey {
+		t.Error("The project `Key` attribute does not match the expected value.")
+	}
+	if project.Is_private != false {
+		t.Error("The project `Is_private` attribute does not match the expected value.")
+	}
+
+	// Delete the project, so we can keep a clean test environment
+	_, err = c.Workspaces.DeleteProject(opt)
+	if err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
The `IsPrivate` was incorrectly named, it should be `Is_private` to match the name returned by the API. This lead to this value always remaining `false`, as the decoder was unable to match the `is_private` key from the API response with `IsPrivate` in the `Project` struct.

Fixes #157

Test Output
```sh
$ BITBUCKET_TEST_USERNAME=? BITBUCKET_TEST_PASSWORD=? BITBUCKET_TEST_OWNER=? go test -v ./tests/project_test.go
=== RUN   TestProjectCreate_isPrivateTrue
--- PASS: TestProjectCreate_isPrivateTrue (1.56s)
=== RUN   TestProjectCreate_isPrivateFalse
--- PASS: TestProjectCreate_isPrivateFalse (0.92s)
PASS
ok      command-line-arguments  2.946s
```