### PR TITLE
Fix bug with `Repository` struct

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -24,7 +24,7 @@ type Repository struct {
 	Slug        string
 	Full_name   string
 	Description string
-	ForkPolicy  string
+	Fork_policy string
 	Language    string
 	Is_private  bool
 	Has_issues  bool


### PR DESCRIPTION
The `ForkPolicy` was incorrectly named, it should be `Fork_policy` to match the key returned by the API.