### PR TITLE
No need to specify the owner to list repositories

### DIFF
--- a/repositories.go
+++ b/repositories.go
@@ -2,6 +2,7 @@ package bitbucket
 
 import (
 	"errors"
+  "fmt"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -31,7 +32,11 @@ type RepositoriesRes struct {
 }
 
 func (r *Repositories) ListForAccount(ro *RepositoriesOptions) (*RepositoriesRes, error) {
-	urlStr := r.c.requestUrl("/repositories/%s", ro.Owner)
+	url := "/repositories"
+	if ro.Owner != "" {
+		url += fmt.Sprintf("/%s", ro.Owner)
+	}
+	urlStr := r.c.requestUrl(url)
 	if ro.Role != "" {
 		urlStr += "?role=" + ro.Role
 	}


### PR DESCRIPTION
We can list repositories to /repositories for an owner if we define a
scope so we let allow it.

Signed-off-by: Chmouel Boudjnah <chmouel@chmouel.com>
