### PR TITLE
Add support for `deploy-keys`

### DIFF
--- a/bitbucket.go
+++ b/bitbucket.go
@@ -527,3 +527,11 @@ type RepositoryDeploymentVariableDeleteOptions struct {
 	Environment *Environment `json:"environment"`
 	Uuid        string       `json:"uuid"`
 }
+
+type DeployKeyOptions struct {
+	Owner    string `json:"owner"`
+	RepoSlug string `json:"repo_slug"`
+	Id       int    `json:"id"`
+	Label    string `json:"label"`
+	Key      string `json:"key"`
+}

--- a/client.go
+++ b/client.go
@@ -1,19 +1,17 @@
 package bitbucket
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
-
+	"mime/multipart"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
-
-	"bytes"
-	"io"
-	"mime/multipart"
-	"os"
 
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
@@ -151,6 +149,7 @@ func injectClient(a *auth) *Client {
 		BranchRestrictions: &BranchRestrictions{c: c},
 		Webhooks:           &Webhooks{c: c},
 		Downloads:          &Downloads{c: c},
+		DeployKeys:         &DeployKeys{c: c},
 	}
 	c.Users = &Users{c: c}
 	c.User = &User{c: c}

--- a/deploykeys.go
+++ b/deploykeys.go
@@ -1,0 +1,75 @@
+package bitbucket
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/k0kubun/pp"
+	"github.com/mitchellh/mapstructure"
+)
+
+type DeployKeys struct {
+	c *Client
+}
+
+type DeployKey struct {
+	Id    int    `json:"id"`
+	Label string `json:"label"`
+	Key   string `json:"key"`
+}
+
+func decodeDeployKey(response interface{}) (*DeployKey, error) {
+	respMap := response.(map[string]interface{})
+
+	if respMap["type"] == "error" {
+		return nil, DecodeError(respMap)
+	}
+
+	var deployKey = new(DeployKey)
+	err := mapstructure.Decode(respMap, deployKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return deployKey, nil
+}
+
+func buildDeployKeysBody(opt *DeployKeyOptions) string {
+	body := map[string]interface{}{}
+	body["label"] = opt.Label
+	body["key"] = opt.Key
+
+	data, err := json.Marshal(body)
+	if err != nil {
+		_, _ = pp.Println(err)
+		os.Exit(9)
+	}
+
+	return string(data)
+}
+
+func (dk *DeployKeys) Create(opt *DeployKeyOptions) (*DeployKey, error) {
+	data := buildDeployKeysBody(opt)
+	urlStr := dk.c.requestUrl("/repositories/%s/%s/deploy-keys", opt.Owner, opt.RepoSlug)
+	response, err := dk.c.execute("POST", urlStr, data)
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeDeployKey(response)
+}
+
+func (dk *DeployKeys) Get(opt *DeployKeyOptions) (*DeployKey, error) {
+	urlStr := dk.c.requestUrl("/repositories/%s/%s/deploy-keys/%d", opt.Owner, opt.RepoSlug, opt.Id)
+	response, err := dk.c.execute("GET", urlStr, "")
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeDeployKey(response)
+}
+
+func (dk *DeployKeys) Delete(opt *DeployKeyOptions) (interface{}, error) {
+	urlStr := dk.c.requestUrl("/repositories/%s/%s/deploy-keys/%d", opt.Owner, opt.RepoSlug, opt.Id)
+	return dk.c.execute("DELETE", urlStr, "")
+}

--- a/repositories.go
+++ b/repositories.go
@@ -2,7 +2,7 @@ package bitbucket
 
 import (
 	"errors"
-  "fmt"
+	"fmt"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -20,6 +20,7 @@ type Repositories struct {
 	BranchRestrictions *BranchRestrictions
 	Webhooks           *Webhooks
 	Downloads          *Downloads
+	DeployKeys         *DeployKeys
 	repositories
 }
 

--- a/tests/deploykeys_test.go
+++ b/tests/deploykeys_test.go
@@ -1,0 +1,102 @@
+package tests
+
+import (
+	"os"
+	"testing"
+
+	_ "github.com/k0kubun/pp"
+
+	"github.com/ktrysmt/go-bitbucket"
+)
+
+func TestDeployKey(t *testing.T) {
+	user := os.Getenv("BITBUCKET_TEST_USERNAME")
+	pass := os.Getenv("BITBUCKET_TEST_PASSWORD")
+	owner := os.Getenv("BITBUCKET_TEST_OWNER")
+	repo := os.Getenv("BITBUCKET_TEST_REPOSLUG")
+
+	if user == "" {
+		t.Error("BITBUCKET_TEST_USERNAME is empty.")
+	}
+	if pass == "" {
+		t.Error("BITBUCKET_TEST_PASSWORD is empty.")
+	}
+	if owner == "" {
+		t.Error("BITBUCKET_TEST_OWNER is empty.")
+	}
+	if repo == "" {
+		t.Error("BITBUCKET_TEST_REPOSLUG is empty.")
+	}
+
+	c := bitbucket.NewBasicAuth(user, pass)
+
+	var deployKeyResourceId int
+
+	label := "go-bb-test"
+	key := "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAK/b1cHHDr/TEV1JGQl+WjCwStKG6Bhrv0rFpEsYlyTBm1fzN0VOJJYn4ZOPCPJwqse6fGbXntEs+BbXiptR+++HycVgl65TMR0b5ul5AgwrVdZdT7qjCOCgaSV74/9xlHDK8oqgGnfA7ZoBBU+qpVyaloSjBdJfLtPY/xqj4yHnXKYzrtn/uFc4Kp9Tb7PUg9Io3qohSTGJGVHnsVblq/rToJG7L5xIo0OxK0SJSQ5vuId93ZuFZrCNMXj8JDHZeSEtjJzpRCBEXHxpOPhAcbm4MzULgkFHhAVgp4JbkrT99/wpvZ7r9AdkTg7HGqL3rlaDrEcWfL7Lu6TnhBdq5"
+
+	t.Run("create", func(t *testing.T) {
+		opt := &bitbucket.DeployKeyOptions{
+			Owner:    owner,
+			RepoSlug: repo,
+			Label:    label,
+			Key:      key,
+		}
+
+		deployKey, err := c.Repositories.DeployKeys.Create(opt)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if deployKey == nil {
+			t.Error("The Deploy Key could not be created.")
+		}
+
+		if deployKey.Label != label {
+			t.Error("The Deploy Key `label` attribute does not match the expected value.")
+		}
+		if deployKey.Key != key {
+			t.Error("The Deploy Key `key` attribute does not match the expected value.")
+		}
+
+		deployKeyResourceId = deployKey.Id
+	})
+
+	t.Run("get", func(t *testing.T) {
+		opt := &bitbucket.DeployKeyOptions{
+			Owner:    owner,
+			RepoSlug: repo,
+			Id:       deployKeyResourceId,
+		}
+		deployKey, err := c.Repositories.DeployKeys.Get(opt)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if deployKey == nil {
+			t.Error("The Deploy Key could not be retrieved.")
+		}
+
+		if deployKey.Id != deployKeyResourceId {
+			t.Error("The Deploy Key `label` attribute does not match the expected value.")
+		}
+		if deployKey.Label != label {
+			t.Error("The Deploy Key `label` attribute does not match the expected value.")
+		}
+		if deployKey.Key != key {
+			t.Error("The Deploy Key `key` attribute does not match the expected value.")
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		opt := &bitbucket.DeployKeyOptions{
+			Owner:    owner,
+			RepoSlug: repo,
+			Id:       deployKeyResourceId,
+		}
+		_, err := c.Repositories.DeployKeys.Delete(opt)
+		if err != nil {
+			t.Error(err)
+		}
+	})
+}


### PR DESCRIPTION
Allows you to create, retrieve & delete deploy keys.

This implements the following API specs:
https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/deploy-keys#post
https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/deploy-keys/%7Bkey_id%7D

Test output
```
go test -v ./tests/deploykeys_test.go
=== RUN   TestDeployKey
=== RUN   TestDeployKey/create
=== RUN   TestDeployKey/get
=== RUN   TestDeployKey/delete
--- PASS: TestDeployKey (1.94s)
    --- PASS: TestDeployKey/create (1.42s)
    --- PASS: TestDeployKey/get (0.27s)
    --- PASS: TestDeployKey/delete (0.25s)
PASS
ok      command-line-arguments  2.414s
```