### PR TITLE
Fix issue with `fork_policy` not being updated

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -774,6 +774,20 @@ func (r *Repository) buildRepositoryBody(ro *RepositoryOptions) string {
 	}
 	if ro.ForkPolicy != "" {
 		body["fork_policy"] = ro.ForkPolicy
+
+		// Due to this undocumented asymmetric behaviour (https://jira.atlassian.com/browse/BCLOUD-13093)
+		// we have to do this, to allow `fork_policy` to be updated after initial creation (i.e. PUT/POST requests)
+		switch ro.ForkPolicy {
+		case "allow_forks":
+			body["no_forks"] = false
+			body["no_public_forks"] = false
+		case "no_public_forks":
+			body["no_forks"] = false
+			body["no_public_forks"] = true
+		case "no_forks":
+			body["no_forks"] = true
+			body["no_public_forks"] = true
+		}
 	}
 	if ro.Language != "" {
 		body["language"] = ro.Language


### PR DESCRIPTION
Due to an undocumented quirk in Bitbucket's API, when updating a repository, you have to pass in two additional fields which are then used together, to match the string representation of the fork_policy (which the API returns - the other two fields are not returned).

Here is a link to an oustanding bug ticket filed with Atlassian: https://jira.atlassian.com/browse/BCLOUD-13093

Also added tests to cover the behaviour above, as well as an additional one for creating a repository, to ensure this functionality was not broken with the changes introduced.