### PR TITLE
ISSUE #166 Update GetDiffStat functionality

### DIFF
--- a/bitbucket.go
+++ b/bitbucket.go
@@ -377,6 +377,7 @@ type DiffStatOptions struct {
 	PageNum    int    `json:"page"`
 	Pagelen    int    `json:"pagelen"`
 	MaxDepth   int    `json:"max_depth"`
+	Fields     []string
 }
 
 type WebhooksOptions struct {

--- a/diff.go
+++ b/diff.go
@@ -2,11 +2,11 @@ package bitbucket
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/url"
 	"strconv"
-
-	"github.com/mitchellh/mapstructure"
+	"strings"
 )
 
 type Diff struct {
@@ -14,21 +14,21 @@ type Diff struct {
 }
 
 type DiffStatRes struct {
-	Page      int
-	Pagelen   int
-	MaxDepth  int
-	Size      int
-	Next      string
-	DiffStats []DiffStat
+	Page      int         `json:"page,omitempty"`
+	Pagelen   int         `json:"pagelen,omitempty"`
+	Size      int         `json:"size,omitempty"`
+	Next      string      `json:"next,omitempty"`
+	Previous  string      `json:"previous,omitempty"`
+	DiffStats []*DiffStat `json:"values,omitempty"`
 }
 
 type DiffStat struct {
-	Type         string
-	Status       string
-	LinesRemoved int
-	LinedAdded   int
-	Old          map[string]interface{}
-	New          map[string]interface{}
+	Type         string                 `json:"type,omitempty"`
+	Status       string                 `json:"status,omitempty"`
+	LinesRemoved int                    `json:"lines_removed,omitempty"`
+	LinedAdded   int                    `json:"lines_added,omitempty"`
+	Old          map[string]interface{} `json:"old,omitempty"`
+	New          map[string]interface{} `json:"new,omitempty"`
 }
 
 func (d *Diff) GetDiff(do *DiffOptions) (interface{}, error) {
@@ -72,6 +72,10 @@ func (d *Diff) GetDiffStat(dso *DiffStatOptions) (*DiffStatRes, error) {
 		params.Add("max_depth", strconv.Itoa(dso.MaxDepth))
 	}
 
+	if len(dso.Fields) > 0 {
+		params.Add("fields", cleanFields(dso.Fields))
+	}
+
 	urlStr := d.c.requestUrl("/repositories/%s/%s/diffstat/%s?%s", dso.Owner, dso.RepoSlug,
 		dso.Spec,
 		params.Encode())
@@ -89,54 +93,20 @@ func (d *Diff) GetDiffStat(dso *DiffStatOptions) (*DiffStatRes, error) {
 
 func decodeDiffStat(diffStatResponseStr string) (*DiffStatRes, error) {
 
-	var diffStatResponseMap map[string]interface{}
-	err := json.Unmarshal([]byte(diffStatResponseStr), &diffStatResponseMap)
+	var diffStatRes DiffStatRes
+
+	err := json.Unmarshal([]byte(diffStatResponseStr), &diffStatRes)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("DiffStat decode error: %w", err)
 	}
 
-	diffStatArray := diffStatResponseMap["values"].([]interface{})
-	var diffStatsSlice []DiffStat
-	for _, diffStatEntry := range diffStatArray {
-		var diffStat DiffStat
-		err = mapstructure.Decode(diffStatEntry, &diffStat)
-		if err == nil {
-			diffStatsSlice = append(diffStatsSlice, diffStat)
-		}
-	}
+	return &diffStatRes, nil
+}
 
-	page, ok := diffStatResponseMap["page"].(float64)
-	if !ok {
-		page = 0
-	}
-
-	pagelen, ok := diffStatResponseMap["pagelen"].(float64)
-	if !ok {
-		pagelen = 0
-	}
-
-	max_depth, ok := diffStatResponseMap["max_depth"].(float64)
-	if !ok {
-		max_depth = 0
-	}
-
-	size, ok := diffStatResponseMap["size"].(float64)
-	if !ok {
-		size = 0
-	}
-
-	next, ok := diffStatResponseMap["next"].(string)
-	if !ok {
-		next = ""
-	}
-
-	diffStats := DiffStatRes{
-		Page:      int(page),
-		Pagelen:   int(pagelen),
-		MaxDepth:  int(max_depth),
-		Size:      int(size),
-		Next:      next,
-		DiffStats: diffStatsSlice,
-	}
-	return &diffStats, nil
+// cleanFields combines all query params in the slice of field strigs into a sigle string
+// and removes any whitespace before returing the string.
+func cleanFields(fields []string) string {
+	interS := strings.Join(fields, ",")
+	s := strings.ReplaceAll(interS, " ", "")
+	return s
 }

--- a/tests/diff_test.go
+++ b/tests/diff_test.go
@@ -79,3 +79,47 @@ func TestGetDiffStat(t *testing.T) {
 		t.Error("Cannot get diffstat.")
 	}
 }
+
+func TestGetDiffStatWithFields(t *testing.T) {
+
+	user := os.Getenv("BITBUCKET_TEST_USERNAME")
+	pass := os.Getenv("BITBUCKET_TEST_PASSWORD")
+	owner := os.Getenv("BITBUCKET_TEST_OWNER")
+	repo := os.Getenv("BITBUCKET_TEST_REPOSLUG")
+
+	if user == "" {
+		t.Error("BITBUCKET_TEST_USERNAME is empty.")
+	}
+
+	if pass == "" {
+		t.Error("BITBUCKET_TEST_PASSWORD is empty.")
+	}
+
+	c := bitbucket.NewBasicAuth(user, pass)
+
+	spec := "master..develop"
+
+	fields := []string{
+		"-page",
+		"-values.lines_removed",
+		"-values.new",
+	}
+
+	opt := &bitbucket.DiffStatOptions{
+		Owner:    owner,
+		RepoSlug: repo,
+		Spec:     spec,
+		Fields:   fields,
+	}
+
+	res, err := c.Repositories.Diff.GetDiffStat(opt)
+	if err != nil {
+		t.Error(err)
+	}
+
+	pp.Println(res)
+
+	if res == nil {
+		t.Error("Cannot get diffstat.")
+	}
+}


### PR DESCRIPTION
This PR will close #166 by updating GetDiffStat functionality.

Specifically we update the GetDiffStat functionality so that now users
can add in a slice of strings named Fields in the DiffStatOptions.
Using this option users can exclude or only include certain parts
of the JSON response. For example if you don't want lines_added
or lines_removed from the values/DiffStat JSON response object
then you would assign 
`DiffStatOptions.Fields = []string{"-values.lines_removed", "-values.lines_added"}`
and if you wanted just lines_added you would instead do
`DiffStatOptions.Fields = []string{"values.lines_added"}`.

Note, currently, given how the json decoding is although we remove the
specified fields from the JSON response, they get unmarshalled as zero
values for the corresponding DiffStatRes fields.

Also, a test was added, but we should probably improve it by testing
whether or not what we removed/selected is present accordingly.