### PR TITLE
Fix bug with incorrect request payload for groups (Branch Restrictions)

### DIFF
--- a/branchrestrictions.go
+++ b/branchrestrictions.go
@@ -82,10 +82,9 @@ type branchRestrictionsBodyGroup struct {
 		Html struct {
 			Href string `json:"href"`
 		} `json:"html"`
-		FullSlug string `json:"full_slug"`
-		Members  int    `json:"members"`
-		Slug     string `json:"slug"`
 	} `json:"links"`
+	FullSlug string `json:"full_slug"`
+	Slug     string `json:"slug"`
 }
 
 type branchRestrictionsBodyUser struct {
@@ -128,7 +127,7 @@ func (b *BranchRestrictions) buildBranchRestrictionsBody(bo *BranchRestrictionsO
 	}
 	for _, g := range bo.Groups {
 		group := branchRestrictionsBodyGroup{
-			Name: g,
+			Slug: g,
 		}
 		groups = append(groups, group)
 	}


### PR DESCRIPTION
The API expects the group slug to be passed in, without this, API returns a HTTP 400 error. Also, fixed `branchRestrictionsBodyGroup` struct, specifically the inner `links` struct which accidentally included `full_slug` & `slug` - both of which should be at the root level.

Previously a request with this payload
```
{"kind":"push","pattern":"develop","links":{"self":{"href":""}},"value":null,"id":0,"users":null,"groups":[{"name":"za-test"}]}
```

Would return
```
{"type":"error","error":{"message":"malformed groups"}}
```

With the fixed payload, we now get a success response.
```
{"kind":"push","pattern":"develop","links":{"self":{"href":""}},"value":null,"id":0,"users":null,"groups":[{"slug":"za-test"}]}
```