### PR TITLE
Add GetPipelineConfig (closes GH-176)

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -544,6 +544,15 @@ func (r *Repository) DeleteDefaultReviewer(rdro *RepositoryDefaultReviewerOption
 	return r.c.execute("DELETE", urlStr, "")
 }
 
+func (r *Repository) GetPipelineConfig(rpo *RepositoryPipelineOptions) (*Pipeline, error) {
+	urlStr := r.c.requestUrl("/repositories/%s/%s/pipelines_config", rpo.Owner, rpo.RepoSlug)
+	response, err := r.c.execute("GET", urlStr, "")
+	if err != nil {
+		return nil, fmt.Errorf("unable to get pipeline config: %w", err)
+	}
+	return decodePipelineRepository(response)
+}
+
 func (r *Repository) UpdatePipelineConfig(rpo *RepositoryPipelineOptions) (*Pipeline, error) {
 	data, err := r.buildPipelineBody(rpo)
 	if err != nil {

--- a/tests/repository_test.go
+++ b/tests/repository_test.go
@@ -189,6 +189,103 @@ func TestRepositoryUpdateForkPolicy(t *testing.T) {
 	}
 }
 
+func TestGetRepositoryPipelineConfig(t *testing.T) {
+	user := os.Getenv("BITBUCKET_TEST_USERNAME")
+	pass := os.Getenv("BITBUCKET_TEST_PASSWORD")
+	owner := os.Getenv("BITBUCKET_TEST_OWNER")
+	repo := os.Getenv("BITBUCKET_TEST_REPOSLUG")
+
+	if user == "" {
+		t.Error("BITBUCKET_TEST_USERNAME is empty.")
+	}
+	if pass == "" {
+		t.Error("BITBUCKET_TEST_PASSWORD is empty.")
+	}
+	if owner == "" {
+		t.Error("BITBUCKET_TEST_OWNER is empty.")
+	}
+	if repo == "" {
+		t.Error("BITBUCKET_TEST_REPOSLUG is empty.")
+	}
+
+	c := bitbucket.NewBasicAuth(user, pass)
+
+	opt := &bitbucket.RepositoryPipelineOptions{
+		Owner:    owner,
+		RepoSlug: repo,
+	}
+
+	res, err := c.Repositories.Repository.GetPipelineConfig(opt)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if res == nil {
+		t.Error("Cannot get pipeline config")
+	}
+	if res.Enabled != false {
+		t.Error("Got wrong pipelines config data")
+	}
+}
+
+func TestUpdateRepositoryPipelineConfig(t *testing.T) {
+	user := os.Getenv("BITBUCKET_TEST_USERNAME")
+	pass := os.Getenv("BITBUCKET_TEST_PASSWORD")
+	owner := os.Getenv("BITBUCKET_TEST_OWNER")
+	repo := os.Getenv("BITBUCKET_TEST_REPOSLUG")
+
+	if user == "" {
+		t.Error("BITBUCKET_TEST_USERNAME is empty.")
+	}
+	if pass == "" {
+		t.Error("BITBUCKET_TEST_PASSWORD is empty.")
+	}
+	if owner == "" {
+		t.Error("BITBUCKET_TEST_OWNER is empty.")
+	}
+	if repo == "" {
+		t.Error("BITBUCKET_TEST_REPOSLUG is empty.")
+	}
+
+	c := bitbucket.NewBasicAuth(user, pass)
+
+	opt := &bitbucket.RepositoryPipelineOptions{
+		Owner:    owner,
+		RepoSlug: repo,
+		Enabled:  true,
+	}
+
+	res, err := c.Repositories.Repository.UpdatePipelineConfig(opt)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if res == nil {
+		t.Error("Cannot update pipeline config")
+	}
+	if res.Enabled != true {
+		t.Error("Got wrong pipelines config data")
+	}
+
+	opt = &bitbucket.RepositoryPipelineOptions{
+		Owner:    owner,
+		RepoSlug: repo,
+		Enabled:  false,
+	}
+
+	res, err = c.Repositories.Repository.UpdatePipelineConfig(opt)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if res == nil {
+		t.Error("Cannot update pipeline config")
+	}
+	if res.Enabled != false {
+		t.Error("Got wrong pipelines config data")
+	}
+}
+
 func TestGetRepositoryPipelineVariables(t *testing.T) {
 
 	user := os.Getenv("BITBUCKET_TEST_USERNAME")


### PR DESCRIPTION
- Adds a new command `GetPipelineConfig` for fetching the current pipeline configuration.
- Adds tests for `GetPipelineConfig`  and `UpdatePipelineConfig`

NB: BitBucket differentiates between not having a pipeline config, and having a pipeline config with `enabled: false`. While there is no difference in practice, the former will return a 404 on the API call, while the latter will successfully return the current (disabled) configuration.