### PR TITLE
Deprecate Repositories.ListForTeam (closes #181)

### DIFF
--- a/repositories.go
+++ b/repositories.go
@@ -45,19 +45,12 @@ func (r *Repositories) ListForAccount(ro *RepositoriesOptions) (*RepositoriesRes
 	if err != nil {
 		return nil, err
 	}
-	return decodeRepositorys(repos)
+	return decodeRepositories(repos)
 }
 
+// Deprecated: Use ListForAccount instead
 func (r *Repositories) ListForTeam(ro *RepositoriesOptions) (*RepositoriesRes, error) {
-	urlStr := r.c.requestUrl("/repositories/%s", ro.Owner)
-	if ro.Role != "" {
-		urlStr += "?role=" + ro.Role
-	}
-	repos, err := r.c.executeRaw("GET", urlStr, "")
-	if err != nil {
-		return nil, err
-	}
-	return decodeRepositorys(repos)
+	return r.ListForAccount(ro)
 }
 
 func (r *Repositories) ListPublic() (*RepositoriesRes, error) {
@@ -66,10 +59,10 @@ func (r *Repositories) ListPublic() (*RepositoriesRes, error) {
 	if err != nil {
 		return nil, err
 	}
-	return decodeRepositorys(repos)
+	return decodeRepositories(repos)
 }
 
-func decodeRepositorys(reposResponse interface{}) (*RepositoriesRes, error) {
+func decodeRepositories(reposResponse interface{}) (*RepositoriesRes, error) {
 	reposResponseMap, ok := reposResponse.(map[string]interface{})
 	if !ok {
 		return nil, errors.New("Not a valid format")

--- a/tests/repositories_test.go
+++ b/tests/repositories_test.go
@@ -1,0 +1,88 @@
+package tests
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ktrysmt/go-bitbucket"
+)
+
+func TestListForAccount(t *testing.T) {
+	user := os.Getenv("BITBUCKET_TEST_USERNAME")
+	pass := os.Getenv("BITBUCKET_TEST_PASSWORD")
+	owner := os.Getenv("BITBUCKET_TEST_OWNER")
+	repo := os.Getenv("BITBUCKET_TEST_REPOSLUG")
+
+	if user == "" {
+		t.Error("BITBUCKET_TEST_USERNAME is empty.")
+	}
+	if pass == "" {
+		t.Error("BITBUCKET_TEST_PASSWORD is empty.")
+	}
+	if owner == "" {
+		t.Error("BITBUCKET_TEST_OWNER is empty.")
+	}
+	if repo == "" {
+		t.Error("BITBUCKET_TEST_REPOSLUG is empty.")
+	}
+
+	c := bitbucket.NewBasicAuth(user, pass)
+
+	repositories, err := c.Repositories.ListForAccount(&bitbucket.RepositoriesOptions{
+		Owner: owner,
+	})
+	if err != nil {
+		t.Error("Unable to fetch repositories")
+	}
+
+	found := false
+	for _, r := range repositories.Items {
+		if r.Slug == repo {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Did not find repository in list")
+	}
+}
+
+func TestListForTeam(t *testing.T) {
+	user := os.Getenv("BITBUCKET_TEST_USERNAME")
+	pass := os.Getenv("BITBUCKET_TEST_PASSWORD")
+	owner := os.Getenv("BITBUCKET_TEST_OWNER")
+	repo := os.Getenv("BITBUCKET_TEST_REPOSLUG")
+
+	if user == "" {
+		t.Error("BITBUCKET_TEST_USERNAME is empty.")
+	}
+	if pass == "" {
+		t.Error("BITBUCKET_TEST_PASSWORD is empty.")
+	}
+	if owner == "" {
+		t.Error("BITBUCKET_TEST_OWNER is empty.")
+	}
+	if repo == "" {
+		t.Error("BITBUCKET_TEST_REPOSLUG is empty.")
+	}
+
+	c := bitbucket.NewBasicAuth(user, pass)
+
+	repositories, err := c.Repositories.ListForTeam(&bitbucket.RepositoriesOptions{
+		Owner: owner,
+	})
+	if err != nil {
+		t.Error("Unable to fetch repositories")
+	}
+
+	found := false
+	for _, r := range repositories.Items {
+		if r.Slug == repo {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Did not find repository in list")
+	}
+}

--- a/tests/repositories_test.go
+++ b/tests/repositories_test.go
@@ -68,7 +68,9 @@ func TestListForTeam(t *testing.T) {
 
 	c := bitbucket.NewBasicAuth(user, pass)
 
+	//goland:noinspection GoDeprecation
 	repositories, err := c.Repositories.ListForTeam(&bitbucket.RepositoriesOptions{
+
 		Owner: owner,
 	})
 	if err != nil {


### PR DESCRIPTION
The `Repositories.ListForTeam` method calls `Client.executeRaw`, most likely due to an oversight in PR #88. This means that any calls to this function will fail.

- Add tests for both `ListForAccount` and ListForTeam`
- Deprecate `ListForTeam` and make it an alias for `ListForAccount`, since it
  performs exactly the same function/request