### PR TITLE
Upon receiving unexpected status code, attempt to retrieve the body

### DIFF
--- a/client.go
+++ b/client.go
@@ -361,7 +361,7 @@ func (c *Client) doRawRequest(req *http.Request, emptyResponse bool) (io.ReadClo
 
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			out.Body = []byte(err.Error())
+			out.Body = []byte(fmt.Sprintf("could not read the response body: %v", err))
 		} else {
 			out.Body = body
 		}

--- a/error.go
+++ b/error.go
@@ -2,6 +2,7 @@ package bitbucket
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -31,4 +32,9 @@ type UnexpectedResponseStatusError struct {
 
 func (e *UnexpectedResponseStatusError) Error() string {
 	return e.Status
+}
+
+// ErrorWithBody returns an error with the given status and body.
+func (e *UnexpectedResponseStatusError) ErrorWithBody() error {
+	return fmt.Errorf("unexpected status %s, body: %s", e.Status, string(e.Body))
 }

--- a/error.go
+++ b/error.go
@@ -20,3 +20,15 @@ func DecodeError(e map[string]interface{}) error {
 
 	return errors.New(bitbucketError.Message)
 }
+
+// UnexpectedResponseStatusError represents an unexpected status code
+// returned from the API, along with the body, if it could be read. If the body
+// could not be read, the body contains the error message trying to read it.
+type UnexpectedResponseStatusError struct {
+	Status string
+	Body   []byte
+}
+
+func (e *UnexpectedResponseStatusError) Error() string {
+	return e.Status
+}


### PR DESCRIPTION
When using this library, we found the inability to read the body limiting when the API returns an unexpected status code. In particular, when the API returns a 400 Bad Request, the body should include some pointers on what went wrong, so it's useful to keep it.

This change is backward compatible with the existing API.