### PR TITLE
fix(client): Avoid division by zero in pagination

### DIFF
--- a/client.go
+++ b/client.go
@@ -320,7 +320,7 @@ func (c *Client) doRequest(req *http.Request, emptyResponse bool) (interface{}, 
 		var values []interface{}
 		for {
 			values = append(values, responsePaginated.Values...)
-			if responsePaginated.Size/responsePaginated.Pagelen <= responsePaginated.Page {
+			if responsePaginated.Pagelen == 0 || responsePaginated.Size/responsePaginated.Pagelen <= responsePaginated.Page {
 				break
 			}
 			newReq, err := http.NewRequest(req.Method, responsePaginated.Next, nil)


### PR DESCRIPTION
The pagination panics if the page length is zero in the latest release (v0.9.38):

```
panic: runtime error: integer divide by zero
```

I also get linting errors since v0.9.37, not sure why yet, looks like false positives, but they were not present before:

```
Error: undeclared name: `bitbucket` (typecheck)
Error: "github.com/ktrysmt/go-bitbucket" imported but not used (typecheck)
```

Related to maxbrunet/bitbucket-semantic-pull-requests#30