### PR TITLE
Don't reuse response struct for multiple requests

### DIFF
--- a/client.go
+++ b/client.go
@@ -324,7 +324,7 @@ func (c *Client) doRequest(req *http.Request, emptyResponse bool) (interface{}, 
 		var values []interface{}
 		for {
 			values = append(values, responsePaginated.Values...)
-			if responsePaginated.Pagelen == 0 || responsePaginated.Size/responsePaginated.Pagelen <= responsePaginated.Page {
+			if len(responsePaginated.Next) == 0 {
 				break
 			}
 			newReq, err := http.NewRequest(req.Method, responsePaginated.Next, nil)
@@ -336,6 +336,8 @@ func (c *Client) doRequest(req *http.Request, emptyResponse bool) (interface{}, 
 			if err != nil {
 				return resBody, err
 			}
+
+			responsePaginated = &Response{}
 			json.NewDecoder(resp).Decode(responsePaginated)
 		}
 		responsePaginated.Values = values


### PR DESCRIPTION
A fix was added in https://github.com/ktrysmt/go-bitbucket/pull/186 for the infinite loop while paging. The problem is that it didn't fix the underlying issue, and the fix actually breaks paging in certain circumstances. For example, if I have 13 repos, and a page size of 10, we'll do 13/10 = 1, which equals the page number of 1, and break without retrieving the second page).

The actual problem was that the `responsePaginated` variable was being reused in the loop, and the json decoder doesn't overwrite fields that aren't present in the response, so it was the `Next` field would end up with the value from the previous page, causing the same page to be requested forever.