### PR TITLE
Added max-depth to the ListFiles function

### DIFF
--- a/bitbucket.go
+++ b/bitbucket.go
@@ -179,6 +179,7 @@ type RepositoryFilesOptions struct {
 	RepoSlug string `json:"repo_slug"`
 	Ref      string `json:"ref"`
 	Path     string `json:"path"`
+	MaxDepth int    `json:"max_depth"`
 }
 
 type RepositoryBlobOptions struct {

--- a/repository.go
+++ b/repository.go
@@ -253,7 +253,7 @@ func (r *Repository) ListFiles(ro *RepositoryFilesOptions) ([]RepositoryFile, er
 	}
 
 	query := url.Query()
-	r.c.addMaxDepthParam(&query, nil)
+	r.c.addMaxDepthParam(&query, &ro.MaxDepth)
 	url.RawQuery = query.Encode()
 
 	urlStr = url.String()


### PR DESCRIPTION
Closes #202 
The [Get file or directory contents](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-source/#api-repositories-workspace-repo-slug-src-commit-path-get) endpoint support in the `max_depth` parameter whereas the `ListFiles` function doesn't. Therefor, I added the `MaxDepth` property to `RepositoryFilesOptions` struct.