### PR TITLE
Added a GetFileContent function

### DIFF
--- a/client.go
+++ b/client.go
@@ -332,7 +332,7 @@ func (c *Client) doRequest(req *http.Request, emptyResponse bool) (interface{}, 
 	var result interface{}
 	if err := json.Unmarshal(responseBytes, &result); err != nil {
 		log.Println("Could not unmarshal JSON payload, returning raw response")
-		return resBody, err
+		return responseBytes, nil
 	}
 	return result, nil
 }

--- a/repository.go
+++ b/repository.go
@@ -243,20 +243,46 @@ func (r *Repository) Get(ro *RepositoryOptions) (*Repository, error) {
 	return decodeRepository(response)
 }
 
-func (r *Repository) ListFiles(ro *RepositoryFilesOptions) ([]RepositoryFile, error) {
+func (r *Repository) buildContentsURL(ro *RepositoryFilesOptions) (string, error) {
 	filePath := path.Join("/repositories", ro.Owner, ro.RepoSlug, "src", ro.Ref, ro.Path) + "/"
 
 	urlStr := r.c.requestUrl(filePath)
 	url, err := url.Parse(urlStr)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	query := url.Query()
 	r.c.addMaxDepthParam(&query, nil)
 	url.RawQuery = query.Encode()
 
-	urlStr = url.String()
+	return url.String(), nil
+}
+
+func (r *Repository) GetFileContent(ro *RepositoryFilesOptions) ([]byte, error) {
+	urlStr, err := r.buildContentsURL(ro)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := r.c.execute("GET", urlStr, "")
+	if err != nil {
+		return nil, err
+	}
+
+	content, ok := response.([]byte)
+	if !ok {
+		return nil, fmt.Errorf("requested path is not a file")
+	}
+
+	return content, nil
+}
+
+func (r *Repository) ListFiles(ro *RepositoryFilesOptions) ([]RepositoryFile, error) {
+	urlStr, err := r.buildContentsURL(ro)
+	if err != nil {
+		return nil, err
+	}
 
 	response, err := r.c.executePaginated("GET", urlStr, "")
 	if err != nil {


### PR DESCRIPTION
Closes #203 
Now the repository module only exports the `ListFiles` function and the [contents endpoint](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-source/#api-repositories-workspace-repo-slug-src-commit-path-get) supports getting a file content and not only listing files.
The `GetFileContent` function queries the same endpoint but handles the response differently.
