### PR TITLE
feat(webhooks): Add List function for webhooks

### DIFF
--- a/tests/webhooks_test.go
+++ b/tests/webhooks_test.go
@@ -140,7 +140,7 @@ func TestWebhook(t *testing.T) {
 		}
 	})
 
-	t.Run("gets", func(t *testing.T) {
+	t.Run("list/gets", func(t *testing.T) {
 		const expectedNumberOfWebhooks = 20
 		var webhookUUIDs []string
 		defer func() {
@@ -178,7 +178,7 @@ func TestWebhook(t *testing.T) {
 		// Use a page length of 5 to ensure the auto paging is working
 		c.Pagelen = 5
 
-		response, err := c.Repositories.Webhooks.Gets(&bitbucket.WebhooksOptions{
+		getsResponse, err := c.Repositories.Webhooks.Gets(&bitbucket.WebhooksOptions{
 			Owner:    owner,
 			RepoSlug: repo,
 		})
@@ -187,7 +187,7 @@ func TestWebhook(t *testing.T) {
 			return
 		}
 
-		responseMap, ok := response.(map[string]interface{})
+		responseMap, ok := getsResponse.(map[string]interface{})
 		if !ok {
 			t.Error(errors.New("response could not be decoded"))
 			return
@@ -195,7 +195,22 @@ func TestWebhook(t *testing.T) {
 
 		values := responseMap["values"].([]interface{})
 		if len(values) != expectedNumberOfWebhooks {
-			t.Error(fmt.Errorf("Expected %d webhooks but got %d. Response: %v", expectedNumberOfWebhooks, len(values), response))
+			t.Error(fmt.Errorf("Expected %d webhooks but got %d. Response: %v", expectedNumberOfWebhooks, len(values), getsResponse))
+			return
+		}
+
+		listResponse, err := c.Repositories.Webhooks.List(&bitbucket.WebhooksOptions{
+			Owner:    owner,
+			RepoSlug: repo,
+		})
+
+		if err != nil {
+			t.Errorf("Failed to list webhooks: %v", err)
+			return
+		}
+
+		if len(listResponse) != expectedNumberOfWebhooks {
+			t.Error(fmt.Errorf("Expected %d webhooks but got %d. Response: %v", expectedNumberOfWebhooks, len(values), listResponse))
 			return
 		}
 	})

--- a/webhooks.go
+++ b/webhooks.go
@@ -36,6 +36,19 @@ func decodeWebhook(response interface{}) (*Webhook, error) {
 	return webhook, nil
 }
 
+func decodeWebhooks(response interface{}) ([]Webhook, error) {
+	webhooks := make([]Webhook, 0)
+	resMap := response.(map[string]interface{})
+	for _, v := range resMap["values"].([]interface{}) {
+		wh, err := decodeWebhook(v)
+		if err != nil {
+			return nil, err
+		}
+		webhooks = append(webhooks, *wh)
+	}
+	return webhooks, nil
+}
+
 func (r *Webhooks) buildWebhooksBody(ro *WebhooksOptions) (string, error) {
 	body := map[string]interface{}{}
 
@@ -59,6 +72,16 @@ func (r *Webhooks) buildWebhooksBody(ro *WebhooksOptions) (string, error) {
 	return string(data), nil
 }
 
+func (r *Webhooks) List(ro *WebhooksOptions) ([]Webhook, error) {
+	urlStr := r.c.requestUrl("/repositories/%s/%s/hooks/", ro.Owner, ro.RepoSlug)
+	res, err := r.c.executePaginated("GET", urlStr, "")
+	if err != nil {
+		return nil, err
+	}
+	return decodeWebhooks(res)
+}
+
+// Deprecate Gets for List call
 func (r *Webhooks) Gets(ro *WebhooksOptions) (interface{}, error) {
 	urlStr := r.c.requestUrl("/repositories/%s/%s/hooks/", ro.Owner, ro.RepoSlug)
 	return r.c.executePaginated("GET", urlStr, "")


### PR DESCRIPTION
Fixes issue #152 

Added List function for webhooks within a repository. It has the same logic as Gets, but is easier to read and will return a slice of webhooks instead of an interface. The Gets method is still implemented to prevent any breaking changes. 