### PR TITLE
Add CreatedOnTime and UpdatedOnTime To Repository

### DIFF
--- a/repositories.go
+++ b/repositories.go
@@ -3,8 +3,6 @@ package bitbucket
 import (
 	"errors"
 	"fmt"
-
-	"github.com/mitchellh/mapstructure"
 )
 
 //"github.com/k0kubun/pp"
@@ -70,10 +68,11 @@ func decodeRepositories(reposResponse interface{}) (*RepositoriesRes, error) {
 	repoArray := reposResponseMap["values"].([]interface{})
 	var repos []Repository
 	for _, repoEntry := range repoArray {
-		var repo Repository
-		err := mapstructure.Decode(repoEntry, &repo)
+		// var repo Repository
+		repo, err := decodeRepository(repoEntry)
+		// err := mapstructure.Decode(repoEntry, &repo)
 		if err == nil {
-			repos = append(repos, repo)
+			repos = append(repos, *repo)
 		}
 	}
 

--- a/repositories.go
+++ b/repositories.go
@@ -68,9 +68,7 @@ func decodeRepositories(reposResponse interface{}) (*RepositoriesRes, error) {
 	repoArray := reposResponseMap["values"].([]interface{})
 	var repos []Repository
 	for _, repoEntry := range repoArray {
-		// var repo Repository
 		repo, err := decodeRepository(repoEntry)
-		// err := mapstructure.Decode(repoEntry, &repo)
 		if err == nil {
 			repos = append(repos, *repo)
 		}


### PR DESCRIPTION
Deprecate the `CreatedOn` and `UpdatedOn` fields for repositories and add `CreatedOnTime` and `UpdatedOnTime` as `*time.Time` types. This is still backwards compatible since the `CreatedOn` and `UpdatedOn` fields were not removed. Consolidated logic to decode a Repository so the `decodeRepositories` function uses the same decode code.