### PR TITLE
Add page and keyword to RepositoriesOptions/CommitsOptions

### DIFF
--- a/bitbucket.go
+++ b/bitbucket.go
@@ -139,8 +139,10 @@ type pipelines interface {
 }
 
 type RepositoriesOptions struct {
-	Owner string `json:"owner"`
-	Role  string `json:"role"` // role=[owner|admin|contributor|member]
+	Owner   string  `json:"owner"`
+	Role    string  `json:"role"` // role=[owner|admin|contributor|member]
+	Page    *int    `json:"page"`
+	Keyword *string `json:"keyword"`
 }
 
 type RepositoryOptions struct {

--- a/bitbucket.go
+++ b/bitbucket.go
@@ -341,6 +341,7 @@ type CommitsOptions struct {
 	Include     string `json:"include"`
 	Exclude     string `json:"exclude"`
 	CommentID   string `json:"comment_id"`
+	Page        *int   `json:"page"`
 }
 
 type CommitStatusOptions struct {

--- a/branchrestrictions.go
+++ b/branchrestrictions.go
@@ -17,7 +17,7 @@ type BranchRestrictions struct {
 
 func (b *BranchRestrictions) Gets(bo *BranchRestrictionsOptions) (interface{}, error) {
 	urlStr := b.c.requestUrl("/repositories/%s/%s/branch-restrictions", bo.Owner, bo.RepoSlug)
-	return b.c.executePaginated("GET", urlStr, "")
+	return b.c.executePaginated("GET", urlStr, "", nil)
 }
 
 func (b *BranchRestrictions) Create(bo *BranchRestrictionsOptions) (*BranchRestrictions, error) {

--- a/client.go
+++ b/client.go
@@ -249,7 +249,7 @@ func (c *Client) execute(method string, urlStr string, text string) (interface{}
 	return result, nil
 }
 
-func (c *Client) executePaginated(method string, urlStr string, text string) (interface{}, error) {
+func (c *Client) executePaginated(method string, urlStr string, text string, page *int) (interface{}, error) {
 	if c.Pagelen != DEFAULT_PAGE_LENGTH {
 		urlObj, err := url.Parse(urlStr)
 		if err != nil {
@@ -271,7 +271,7 @@ func (c *Client) executePaginated(method string, urlStr string, text string) (in
 	}
 
 	c.authenticateRequest(req)
-	result, err := c.doPaginatedRequest(req, false)
+	result, err := c.doPaginatedRequest(req, page, false)
 	if err != nil {
 		return nil, err
 	}
@@ -358,7 +358,19 @@ func (c *Client) doRequest(req *http.Request, emptyResponse bool) (interface{}, 
 	return result, nil
 }
 
-func (c *Client) doPaginatedRequest(req *http.Request, emptyResponse bool) (interface{}, error) {
+func (c *Client) doPaginatedRequest(req *http.Request, page *int, emptyResponse bool) (interface{}, error) {
+	disableAutoPaging := c.DisableAutoPaging
+	curPage := 1
+	if page != nil {
+		disableAutoPaging = true
+		curPage = *page
+		q := req.URL.Query()
+		q.Set("page", strconv.Itoa(curPage))
+		req.URL.RawQuery = q.Encode()
+	}
+	// q.Encode() does not encode "~".
+	req.URL.RawQuery = strings.ReplaceAll(req.URL.RawQuery, "~", "%7E")
+
 	resBody, err := c.doRawRequest(req, emptyResponse)
 	if err != nil {
 		return nil, err
@@ -375,18 +387,15 @@ func (c *Client) doPaginatedRequest(req *http.Request, emptyResponse bool) (inte
 	}
 
 	responsePaginated := &Response{}
-	var curPage int
-
 	err = json.Unmarshal(responseBytes, responsePaginated)
 	if err == nil && len(responsePaginated.Values) > 0 {
-		var values []interface{}
+		values := responsePaginated.Values
 		for {
-			curPage++
-			values = append(values, responsePaginated.Values...)
-			if c.DisableAutoPaging || len(responsePaginated.Next) == 0 ||
+			if disableAutoPaging || responsePaginated.Next == "" ||
 				(curPage >= c.LimitPages && c.LimitPages != 0) {
 				break
 			}
+			curPage++
 			newReq, err := http.NewRequest(req.Method, responsePaginated.Next, nil)
 			if err != nil {
 				return resBody, err
@@ -399,6 +408,7 @@ func (c *Client) doPaginatedRequest(req *http.Request, emptyResponse bool) (inte
 
 			responsePaginated = &Response{}
 			json.NewDecoder(resp).Decode(responsePaginated)
+			values = append(values, responsePaginated.Values...)
 		}
 		responsePaginated.Values = values
 		responseBytes, err = json.Marshal(responsePaginated)

--- a/commits.go
+++ b/commits.go
@@ -12,7 +12,7 @@ type Commits struct {
 func (cm *Commits) GetCommits(cmo *CommitsOptions) (interface{}, error) {
 	urlStr := cm.c.requestUrl("/repositories/%s/%s/commits/%s", cmo.Owner, cmo.RepoSlug, cmo.Branchortag)
 	urlStr += cm.buildCommitsQuery(cmo.Include, cmo.Exclude)
-	return cm.c.executePaginated("GET", urlStr, "")
+	return cm.c.executePaginated("GET", urlStr, "", nil)
 }
 
 func (cm *Commits) GetCommit(cmo *CommitsOptions) (interface{}, error) {
@@ -22,7 +22,7 @@ func (cm *Commits) GetCommit(cmo *CommitsOptions) (interface{}, error) {
 
 func (cm *Commits) GetCommitComments(cmo *CommitsOptions) (interface{}, error) {
 	urlStr := cm.c.requestUrl("/repositories/%s/%s/commit/%s/comments", cmo.Owner, cmo.RepoSlug, cmo.Revision)
-	return cm.c.executePaginated("GET", urlStr, "")
+	return cm.c.executePaginated("GET", urlStr, "", nil)
 }
 
 func (cm *Commits) GetCommitComment(cmo *CommitsOptions) (interface{}, error) {
@@ -32,7 +32,7 @@ func (cm *Commits) GetCommitComment(cmo *CommitsOptions) (interface{}, error) {
 
 func (cm *Commits) GetCommitStatuses(cmo *CommitsOptions) (interface{}, error) {
 	urlStr := cm.c.requestUrl("/repositories/%s/%s/commit/%s/statuses", cmo.Owner, cmo.RepoSlug, cmo.Revision)
-	return cm.c.executePaginated("GET", urlStr, "")
+	return cm.c.executePaginated("GET", urlStr, "", nil)
 }
 
 func (cm *Commits) GetCommitStatus(cmo *CommitsOptions, commitStatusKey string) (interface{}, error) {

--- a/commits.go
+++ b/commits.go
@@ -12,7 +12,7 @@ type Commits struct {
 func (cm *Commits) GetCommits(cmo *CommitsOptions) (interface{}, error) {
 	urlStr := cm.c.requestUrl("/repositories/%s/%s/commits/%s", cmo.Owner, cmo.RepoSlug, cmo.Branchortag)
 	urlStr += cm.buildCommitsQuery(cmo.Include, cmo.Exclude)
-	return cm.c.executePaginated("GET", urlStr, "", nil)
+	return cm.c.executePaginated("GET", urlStr, "", cmo.Page)
 }
 
 func (cm *Commits) GetCommit(cmo *CommitsOptions) (interface{}, error) {

--- a/downloads.go
+++ b/downloads.go
@@ -11,5 +11,5 @@ func (dl *Downloads) Create(do *DownloadsOptions) (interface{}, error) {
 
 func (dl *Downloads) List(do *DownloadsOptions) (interface{}, error) {
 	urlStr := dl.c.requestUrl("/repositories/%s/%s/downloads", do.Owner, do.RepoSlug)
-	return dl.c.executePaginated("GET", urlStr, "")
+	return dl.c.executePaginated("GET", urlStr, "", nil)
 }

--- a/issues.go
+++ b/issues.go
@@ -37,7 +37,7 @@ func (p *Issues) Gets(io *IssuesOptions) (interface{}, error) {
 		url.RawQuery = query.Encode()
 	}
 
-	return p.c.executePaginated("GET", url.String(), "")
+	return p.c.executePaginated("GET", url.String(), "", nil)
 }
 
 func (p *Issues) Get(io *IssuesOptions) (interface{}, error) {

--- a/pipelines.go
+++ b/pipelines.go
@@ -46,7 +46,7 @@ func (p *Pipelines) List(po *PipelinesOptions) (interface{}, error) {
 		urlStr = parsed.String()
 	}
 
-	return p.c.executePaginated("GET", urlStr, "")
+	return p.c.executePaginated("GET", urlStr, "", nil)
 }
 
 func (p *Pipelines) Get(po *PipelinesOptions) (interface{}, error) {
@@ -90,7 +90,7 @@ func (p *Pipelines) ListSteps(po *PipelinesOptions) (interface{}, error) {
 		urlStr = parsed.String()
 	}
 
-	return p.c.executePaginated("GET", urlStr, "")
+	return p.c.executePaginated("GET", urlStr, "", nil)
 }
 
 func (p *Pipelines) GetStep(po *PipelinesOptions) (interface{}, error) {

--- a/pullrequests.go
+++ b/pullrequests.go
@@ -65,7 +65,7 @@ func (p *PullRequests) Gets(po *PullRequestsOptions) (interface{}, error) {
 		urlStr = parsed.String()
 	}
 
-	return p.c.executePaginated("GET", urlStr, "")
+	return p.c.executePaginated("GET", urlStr, "", nil)
 }
 
 func (p *PullRequests) Get(po *PullRequestsOptions) (interface{}, error) {
@@ -75,7 +75,7 @@ func (p *PullRequests) Get(po *PullRequestsOptions) (interface{}, error) {
 
 func (p *PullRequests) Activities(po *PullRequestsOptions) (interface{}, error) {
 	urlStr := p.c.GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/activity"
-	return p.c.executePaginated("GET", urlStr, "")
+	return p.c.executePaginated("GET", urlStr, "", nil)
 }
 
 func (p *PullRequests) Activity(po *PullRequestsOptions) (interface{}, error) {
@@ -85,7 +85,7 @@ func (p *PullRequests) Activity(po *PullRequestsOptions) (interface{}, error) {
 
 func (p *PullRequests) Commits(po *PullRequestsOptions) (interface{}, error) {
 	urlStr := p.c.GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID + "/commits"
-	return p.c.executePaginated("GET", urlStr, "")
+	return p.c.executePaginated("GET", urlStr, "", nil)
 }
 
 func (p *PullRequests) Patch(po *PullRequestsOptions) (interface{}, error) {
@@ -158,7 +158,7 @@ func (p *PullRequests) UpdateComment(co *PullRequestCommentOptions) (interface{}
 
 func (p *PullRequests) GetComments(po *PullRequestsOptions) (interface{}, error) {
 	urlStr := p.c.GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID + "/comments/"
-	return p.c.executePaginated("GET", urlStr, "")
+	return p.c.executePaginated("GET", urlStr, "", nil)
 }
 
 func (p *PullRequests) GetComment(po *PullRequestsOptions) (interface{}, error) {
@@ -189,7 +189,7 @@ func (p *PullRequests) Statuses(po *PullRequestsOptions) (interface{}, error) {
 		parsed.RawQuery = query.Encode()
 		urlStr = parsed.String()
 	}
-	return p.c.executePaginated("GET", urlStr, "")
+	return p.c.executePaginated("GET", urlStr, "", nil)
 }
 
 func (p *PullRequests) buildPullRequestBody(po *PullRequestsOptions) (string, error) {

--- a/repositories.go
+++ b/repositories.go
@@ -32,15 +32,22 @@ type RepositoriesRes struct {
 }
 
 func (r *Repositories) ListForAccount(ro *RepositoriesOptions) (*RepositoriesRes, error) {
-	url := "/repositories"
+	urlPath := "/repositories"
 	if ro.Owner != "" {
-		url += fmt.Sprintf("/%s", ro.Owner)
+		urlPath += fmt.Sprintf("/%s", ro.Owner)
 	}
-	urlStr := r.c.requestUrl(url)
+	urlStr := r.c.requestUrl(urlPath)
 	if ro.Role != "" {
 		urlStr += "?role=" + ro.Role
 	}
-	repos, err := r.c.executePaginated("GET", urlStr, "")
+	if ro.Keyword != nil && *ro.Keyword != "" {
+		if ro.Role == "" {
+			urlStr += "?"
+		}
+		// https://developer.atlassian.com/cloud/bitbucket/rest/intro/#operators
+		urlStr += fmt.Sprintf("q=full_name ~ \"%s\"", *ro.Keyword)
+	}
+	repos, err := r.c.executePaginated("GET", urlStr, "", ro.Page)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +61,7 @@ func (r *Repositories) ListForTeam(ro *RepositoriesOptions) (*RepositoriesRes, e
 
 func (r *Repositories) ListPublic() (*RepositoriesRes, error) {
 	urlStr := r.c.requestUrl("/repositories/")
-	repos, err := r.c.executePaginated("GET", urlStr, "")
+	repos, err := r.c.executePaginated("GET", urlStr, "", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/repository.go
+++ b/repository.go
@@ -324,7 +324,7 @@ func (r *Repository) ListFiles(ro *RepositoryFilesOptions) ([]RepositoryFile, er
 		return nil, err
 	}
 
-	response, err := r.c.executePaginated("GET", urlStr, "")
+	response, err := r.c.executePaginated("GET", urlStr, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -522,7 +522,7 @@ func (r *Repository) ListTags(rbo *RepositoryTagOptions) (*RepositoryTags, error
 	}
 
 	urlStr := r.c.requestUrl("/repositories/%s/%s/refs/tags?%s", rbo.Owner, rbo.RepoSlug, params.Encode())
-	response, err := r.c.executePaginated("GET", urlStr, "")
+	response, err := r.c.executePaginated("GET", urlStr, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -578,18 +578,18 @@ func (r *Repository) Delete(ro *RepositoryOptions) (interface{}, error) {
 
 func (r *Repository) ListWatchers(ro *RepositoryOptions) (interface{}, error) {
 	urlStr := r.c.requestUrl("/repositories/%s/%s/watchers", ro.Owner, ro.RepoSlug)
-	return r.c.executePaginated("GET", urlStr, "")
+	return r.c.executePaginated("GET", urlStr, "", nil)
 }
 
 func (r *Repository) ListForks(ro *RepositoryOptions) (interface{}, error) {
 	urlStr := r.c.requestUrl("/repositories/%s/%s/forks", ro.Owner, ro.RepoSlug)
-	return r.c.executePaginated("GET", urlStr, "")
+	return r.c.executePaginated("GET", urlStr, "", nil)
 }
 
 func (r *Repository) ListDefaultReviewers(ro *RepositoryOptions) (*DefaultReviewers, error) {
 	urlStr := r.c.requestUrl("/repositories/%s/%s/default-reviewers?pagelen=1", ro.Owner, ro.RepoSlug)
 
-	res, err := r.c.executePaginated("GET", urlStr, "")
+	res, err := r.c.executePaginated("GET", urlStr, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -893,7 +893,7 @@ func (r *Repository) UpdateDeploymentVariable(opt *RepositoryDeploymentVariableO
 func (r *Repository) ListGroupPermissions(ro *RepositoryOptions) (*GroupPermissions, error) {
 	urlStr := r.c.requestUrl("/repositories/%s/%s/permissions-config/groups?pagelen=1", ro.Owner, ro.RepoSlug)
 
-	res, err := r.c.executePaginated("GET", urlStr, "")
+	res, err := r.c.executePaginated("GET", urlStr, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -924,7 +924,7 @@ func (r *Repository) DeleteGroupPermissions(rgo *RepositoryGroupPermissionsOptio
 func (r *Repository) GetGroupPermissions(rgo *RepositoryGroupPermissionsOptions) (*GroupPermission, error) {
 	urlStr := r.c.requestUrl("/repositories/%s/%s/permissions-config/groups/%s", rgo.Owner, rgo.RepoSlug, rgo.Group)
 
-	res, err := r.c.executePaginated("GET", urlStr, "")
+	res, err := r.c.executePaginated("GET", urlStr, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -934,7 +934,7 @@ func (r *Repository) GetGroupPermissions(rgo *RepositoryGroupPermissionsOptions)
 func (r *Repository) ListUserPermissions(ro *RepositoryOptions) (*UserPermissions, error) {
 	urlStr := r.c.requestUrl("/repositories/%s/%s/permissions-config/users?pagelen=1", ro.Owner, ro.RepoSlug)
 
-	res, err := r.c.executePaginated("GET", urlStr, "")
+	res, err := r.c.executePaginated("GET", urlStr, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -965,7 +965,7 @@ func (r *Repository) DeleteUserPermissions(rgo *RepositoryUserPermissionsOptions
 func (r *Repository) GetUserPermissions(rgo *RepositoryUserPermissionsOptions) (*UserPermission, error) {
 	urlStr := r.c.requestUrl("/repositories/%s/%s/permissions-config/users/%s", rgo.Owner, rgo.RepoSlug, rgo.User)
 
-	res, err := r.c.executePaginated("GET", urlStr, "")
+	res, err := r.c.executePaginated("GET", urlStr, "", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/webhooks.go
+++ b/webhooks.go
@@ -74,7 +74,7 @@ func (r *Webhooks) buildWebhooksBody(ro *WebhooksOptions) (string, error) {
 
 func (r *Webhooks) List(ro *WebhooksOptions) ([]Webhook, error) {
 	urlStr := r.c.requestUrl("/repositories/%s/%s/hooks/", ro.Owner, ro.RepoSlug)
-	res, err := r.c.executePaginated("GET", urlStr, "")
+	res, err := r.c.executePaginated("GET", urlStr, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func (r *Webhooks) List(ro *WebhooksOptions) ([]Webhook, error) {
 // Deprecate Gets for List call
 func (r *Webhooks) Gets(ro *WebhooksOptions) (interface{}, error) {
 	urlStr := r.c.requestUrl("/repositories/%s/%s/hooks/", ro.Owner, ro.RepoSlug)
-	return r.c.executePaginated("GET", urlStr, "")
+	return r.c.executePaginated("GET", urlStr, "", nil)
 }
 
 func (r *Webhooks) Create(ro *WebhooksOptions) (*Webhook, error) {

--- a/workspaces.go
+++ b/workspaces.go
@@ -52,7 +52,7 @@ type WorkspaceMembers struct {
 
 func (t *Permission) GetUserPermissions(organization, member string) (*Permission, error) {
 	urlStr := t.c.requestUrl("/workspaces/%s/permissions?q=user.nickname=\"%s\"", organization, member)
-	response, err := t.c.executePaginated("GET", urlStr, "")
+	response, err := t.c.executePaginated("GET", urlStr, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func (t *Permission) GetUserPermissions(organization, member string) (*Permissio
 
 func (t *Permission) GetUserPermissionsByUuid(organization, member string) (*Permission, error) {
 	urlStr := t.c.requestUrl("/workspaces/%s/permissions?q=user.uuid=\"%s\"", organization, member)
-	response, err := t.c.executePaginated("GET", urlStr, "")
+	response, err := t.c.executePaginated("GET", urlStr, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func (t *Permission) GetUserPermissionsByUuid(organization, member string) (*Per
 
 func (t *Workspace) List() (*WorkspaceList, error) {
 	urlStr := t.c.requestUrl("/workspaces")
-	response, err := t.c.executePaginated("GET", urlStr, "")
+	response, err := t.c.executePaginated("GET", urlStr, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (t *Workspace) Get(workspace string) (*Workspace, error) {
 
 func (w *Workspace) Members(teamname string) (*WorkspaceMembers, error) {
 	urlStr := w.c.requestUrl("/workspaces/%s/members", teamname)
-	response, err := w.c.executePaginated("GET", urlStr, "")
+	response, err := w.c.executePaginated("GET", urlStr, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func (w *Workspace) Members(teamname string) (*WorkspaceMembers, error) {
 
 func (w *Workspace) Projects(teamname string) (*ProjectsRes, error) {
 	urlStr := w.c.requestUrl("/workspaces/%s/projects/", teamname)
-	response, err := w.c.executePaginated("GET", urlStr, "")
+	response, err := w.c.executePaginated("GET", urlStr, "", nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`page` and `keyword` are added to `RepositoriesOptions` fields.

`page` is useful when items only in a certain page are required.
There are `prev` and `next` in responses of BitBucket list APIs. However, these are urls with just adjacent page numbers like below.
```
{
  "size": 5421,
  "page": 2,
  "pagelen": 10,
  "next": "https://api.bitbucket.org/2.0/repositories/pypy/pypy/commits?page=3",
  "previous": "https://api.bitbucket.org/2.0/repositories/pypy/pypy/commits?page=1",
  "values": [
    ...
  ]
}
```
It means users can specify a page they want directly.

`page` query parameter is set in `doPaginatedRequest`. When `page` is explicitly provided, `DisableAutoPaging` is always `true`.

`keyword` is for filtering repositories on server side. I encountered users with hundreds of repositories in a workspace, and they had to search and select one repository they want to integrate into our service. It takes too long to search on client side, since it has to make several API calls to fetch all repositories.

Keyword search is implemented with [`~` operation of BitBucket query](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#operators).

