### PR TITLE
feat: support multiple files in WriteFileBlob (commit)

### DIFF
--- a/bitbucket.go
+++ b/bitbucket.go
@@ -191,12 +191,18 @@ type RepositoryBlobOptions struct {
 	Path     string `json:"path"`
 }
 
+type File struct {
+	Path string
+	Name string
+}
+
 // Based on https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/src#post
 type RepositoryBlobWriteOptions struct {
 	Owner    string `json:"owner"`
 	RepoSlug string `json:"repo_slug"`
 	FilePath string `json:"filepath"`
 	FileName string `json:"filename"`
+	Files    []File `json:"files"`
 	Author   string `json:"author"`
 	Message  string `json:"message"`
 	Branch   string `json:"branch"`
@@ -455,6 +461,7 @@ type DownloadsOptions struct {
 	RepoSlug string `json:"repo_slug"`
 	FilePath string `json:"filepath"`
 	FileName string `json:"filename"`
+	Files    []File `json:"files"`
 }
 
 type PageRes struct {

--- a/downloads.go
+++ b/downloads.go
@@ -1,12 +1,24 @@
 package bitbucket
 
+import "fmt"
+
 type Downloads struct {
 	c *Client
 }
 
 func (dl *Downloads) Create(do *DownloadsOptions) (interface{}, error) {
 	urlStr := dl.c.requestUrl("/repositories/%s/%s/downloads", do.Owner, do.RepoSlug)
-	return dl.c.executeFileUpload("POST", urlStr, do.FilePath, do.FileName, "files", make(map[string]string))
+
+	if do.FileName != "" {
+		if len(do.Files) > 0 {
+			return nil, fmt.Errorf("can't specify both files and filename")
+		}
+		do.Files = []File{{
+			Path: do.FileName,
+			Name: do.FileName,
+		}}
+	}
+	return dl.c.executeFileUpload("POST", urlStr, do.Files, make(map[string]string))
 }
 
 func (dl *Downloads) List(do *DownloadsOptions) (interface{}, error) {

--- a/repository.go
+++ b/repository.go
@@ -387,9 +387,19 @@ func (r *Repository) WriteFileBlob(ro *RepositoryBlobWriteOptions) error {
 		m["branch"] = ro.Branch
 	}
 
+	if ro.FileName != "" {
+		if len(ro.Files) > 0 {
+			return fmt.Errorf("can't specify both files and filename")
+		}
+		ro.Files = []File{{
+			Path: ro.FileName,
+			Name: ro.FileName,
+		}}
+	}
+
 	urlStr := r.c.requestUrl("/repositories/%s/%s/src", ro.Owner, ro.RepoSlug)
 
-	_, err := r.c.executeFileUpload("POST", urlStr, ro.FilePath, ro.FileName, ro.FileName, m)
+	_, err := r.c.executeFileUpload("POST", urlStr, ro.Files, m)
 	return err
 }
 


### PR DESCRIPTION
This will make it possible to add multiple files in a commit.
Should probably make `File` and `FilePath` deprecated parameters and remove in future releases but for now both are supported to avoid breaking changes.