### PR TITLE
feat: add support for webhook secrets

### DIFF
--- a/bitbucket.go
+++ b/bitbucket.go
@@ -395,6 +395,7 @@ type WebhooksOptions struct {
 	Owner       string   `json:"owner"`
 	RepoSlug    string   `json:"repo_slug"`
 	Uuid        string   `json:"uuid"`
+	Secret      string   `json:"secret"`
 	Description string   `json:"description"`
 	Url         string   `json:"url"`
 	Active      bool     `json:"active"`

--- a/tests/webhooks_test.go
+++ b/tests/webhooks_test.go
@@ -36,6 +36,7 @@ func TestWebhook(t *testing.T) {
 		opt := &bitbucket.WebhooksOptions{
 			Owner:       owner,
 			RepoSlug:    repo,
+			Secret:      "unsecureSecret",
 			Description: "go-bb-test",
 			Url:         "https://example.com",
 			Active:      false,
@@ -62,6 +63,9 @@ func TestWebhook(t *testing.T) {
 		}
 		if len(webhook.Events) != 2 {
 			t.Error("The webhook `events` attribute does not match the expected value.")
+		}
+		if webhook.Secret != "unsecureSecret" {
+			t.Error("The webhook `secret` attribute does not match the expected value.")
 		}
 
 		webhookResourceUuid = webhook.Uuid
@@ -94,6 +98,9 @@ func TestWebhook(t *testing.T) {
 		if len(webhook.Events) != 2 {
 			t.Error("The webhook `events` attribute does not match the expected value.")
 		}
+		if webhook.Secret != "unsecureSecret" {
+			t.Error("The webhook `secret` attribute does not match the expected value.")
+		}
 	})
 
 	t.Run("update", func(t *testing.T) {
@@ -101,6 +108,7 @@ func TestWebhook(t *testing.T) {
 			Owner:       owner,
 			RepoSlug:    repo,
 			Uuid:        webhookResourceUuid,
+			Secret:      "newUnsecureSecret",
 			Description: "go-bb-test-new",
 			Url:         "https://new-example.com",
 			Events:      []string{bitbucket.RepoPushEvent, bitbucket.IssueCreatedEvent, bitbucket.RepoForkEvent},
@@ -125,6 +133,9 @@ func TestWebhook(t *testing.T) {
 		}
 		if len(webhook.Events) != 3 {
 			t.Error("The webhook `events` attribute does not match the expected value.")
+		}
+		if webhook.Secret != "newUnsecureSecret" {
+			t.Error("The webhook `secret` attribute does not match the expected value.")
 		}
 	})
 
@@ -161,6 +172,7 @@ func TestWebhook(t *testing.T) {
 			opt := &bitbucket.WebhooksOptions{
 				Owner:       owner,
 				RepoSlug:    repo,
+				Secret:      "unsecureSecret",
 				Description: fmt.Sprintf("go-bb-test-%d", i),
 				Url:         fmt.Sprintf("https://example.com/%d", i),
 				Active:      false,

--- a/webhooks.go
+++ b/webhooks.go
@@ -14,6 +14,7 @@ type Webhook struct {
 	Owner       string   `json:"owner"`
 	RepoSlug    string   `json:"repo_slug"`
 	Uuid        string   `json:"uuid"`
+	Secret      string   `json:"secret"`
 	Description string   `json:"description"`
 	Url         string   `json:"url"`
 	Active      bool     `json:"active"`
@@ -60,6 +61,9 @@ func (r *Webhooks) buildWebhooksBody(ro *WebhooksOptions) (string, error) {
 	}
 	if ro.Active == true || ro.Active == false {
 		body["active"] = ro.Active
+	}
+	if ro.Secret != "" {
+		body["secret"] = ro.Secret
 	}
 
 	body["events"] = ro.Events


### PR DESCRIPTION
Adding support for secrets within webhooks. 

API ref: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-repositories-workspace-repo-slug-hooks-post