### PR TITLE
feat: add comment parent id

### DIFF
--- a/bitbucket.go
+++ b/bitbucket.go
@@ -299,6 +299,7 @@ type PullRequestCommentOptions struct {
 	PullRequestID string `json:"id"`
 	Content       string `json:"content"`
 	CommentId     string `json:"-"`
+	Parent        *int    `json:"parent"`
 }
 
 type IssuesOptions struct {

--- a/bitbucket.go
+++ b/bitbucket.go
@@ -299,7 +299,7 @@ type PullRequestCommentOptions struct {
 	PullRequestID string `json:"id"`
 	Content       string `json:"content"`
 	CommentId     string `json:"-"`
-	Parent        *int    `json:"parent"`
+	Parent        *int   `json:"parent"`
 }
 
 type IssuesOptions struct {

--- a/pullrequests.go
+++ b/pullrequests.go
@@ -255,6 +255,12 @@ func (p *PullRequests) buildPullRequestCommentBody(co *PullRequestCommentOptions
 		"raw": co.Content,
 	}
 
+	if co.Parent != nil {
+		body["parent"] = map[string]interface{}{
+			"id": co.Parent,
+		}
+	}
+
 	data, err := json.Marshal(body)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Adding support for parent id within comments aka reply. 

API ref: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pullrequests/#api-repositories-workspace-repo-slug-pullrequests-pull-request-id-comments-post-request-body

