### PR TITLE
add ability to delete files

### DIFF
--- a/bitbucket.go
+++ b/bitbucket.go
@@ -198,14 +198,15 @@ type File struct {
 
 // Based on https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/src#post
 type RepositoryBlobWriteOptions struct {
-	Owner    string `json:"owner"`
-	RepoSlug string `json:"repo_slug"`
-	FilePath string `json:"filepath"`
-	FileName string `json:"filename"`
-	Files    []File `json:"files"`
-	Author   string `json:"author"`
-	Message  string `json:"message"`
-	Branch   string `json:"branch"`
+	Owner         string   `json:"owner"`
+	RepoSlug      string   `json:"repo_slug"`
+	FilePath      string   `json:"filepath"`
+	FileName      string   `json:"filename"`
+	Files         []File   `json:"files"`
+	FilesToDelete []string `json:"files_to_delete"`
+	Author        string   `json:"author"`
+	Message       string   `json:"message"`
+	Branch        string   `json:"branch"`
 }
 
 // RepositoryRefOptions represents the options for describing a repository's refs (i.e.

--- a/client.go
+++ b/client.go
@@ -279,7 +279,7 @@ func (c *Client) executePaginated(method string, urlStr string, text string, pag
 	return result, nil
 }
 
-func (c *Client) executeFileUpload(method string, urlStr string, files []File, params map[string]string) (interface{}, error) {
+func (c *Client) executeFileUpload(method string, urlStr string, files []File, filesToDelete []string, params map[string]string) (interface{}, error) {
 	// Prepare a form that you will submit to that URL.
 	var b bytes.Buffer
 	w := multipart.NewWriter(&b)
@@ -303,6 +303,13 @@ func (c *Client) executeFileUpload(method string, urlStr string, files []File, p
 
 	for key, value := range params {
 		err := w.WriteField(key, value)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for _, filename := range filesToDelete {
+		err := w.WriteField("files", filename)
 		if err != nil {
 			return nil, err
 		}

--- a/downloads.go
+++ b/downloads.go
@@ -18,7 +18,7 @@ func (dl *Downloads) Create(do *DownloadsOptions) (interface{}, error) {
 			Name: do.FileName,
 		}}
 	}
-	return dl.c.executeFileUpload("POST", urlStr, do.Files, make(map[string]string))
+	return dl.c.executeFileUpload("POST", urlStr, do.Files, []string{}, make(map[string]string))
 }
 
 func (dl *Downloads) List(do *DownloadsOptions) (interface{}, error) {

--- a/repository.go
+++ b/repository.go
@@ -399,7 +399,7 @@ func (r *Repository) WriteFileBlob(ro *RepositoryBlobWriteOptions) error {
 
 	urlStr := r.c.requestUrl("/repositories/%s/%s/src", ro.Owner, ro.RepoSlug)
 
-	_, err := r.c.executeFileUpload("POST", urlStr, ro.Files, m)
+	_, err := r.c.executeFileUpload("POST", urlStr, ro.Files, ro.FilesToDelete, m)
 	return err
 }
 


### PR DESCRIPTION
Couldn't figure out a way to delete files from the repository using the existing `WriteFileBlob`, so I made some edits to support deleting files from a repo, using the `files` parameter in the request, as detailed in the BitBucket docs [here](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-source/#api-repositories-workspace-repo-slug-src-post).