### PR TITLE
Add FromPullRequest to GetDiffStat

### DIFF
--- a/bitbucket.go
+++ b/bitbucket.go
@@ -249,7 +249,7 @@ type RepositoryBranchDeleteOptions struct {
 	RepoSlug string `json:"repo_slug"`
 	RepoUUID string `json:"uuid"`
 	RefName  string `json:"name"`
-	RefUUID  string `json:uuid`
+	RefUUID  string `json:"uuid"`
 }
 
 type RepositoryBranchTarget struct {
@@ -382,17 +382,19 @@ type DiffOptions struct {
 }
 
 type DiffStatOptions struct {
-	Owner      string `json:"owner"`
-	RepoSlug   string `json:"repo_slug"`
-	Spec       string `json:"spec"`
-	Whitespace bool   `json:"ignore_whitespace"`
-	Merge      bool   `json:"merge"`
-	Path       string `json:"path"`
-	Renames    bool   `json:"renames"`
-	PageNum    int    `json:"page"`
-	Pagelen    int    `json:"pagelen"`
-	MaxDepth   int    `json:"max_depth"`
-	Fields     []string
+	Owner             string `json:"owner"`
+	RepoSlug          string `json:"repo_slug"`
+	Spec              string `json:"spec"`
+	FromPullRequestID int    `json:"from_pullrequest_id"`
+	Whitespace        bool   `json:"ignore_whitespace"`
+	Merge             bool   `json:"merge"`
+	Path              string `json:"path"`
+	Renames           bool   `json:"renames"`
+	Topic             bool   `json:"topic"`
+	PageNum           int    `json:"page"`
+	Pagelen           int    `json:"pagelen"`
+	MaxDepth          int    `json:"max_depth"`
+	Fields            []string
 }
 
 type WebhooksOptions struct {

--- a/diff.go
+++ b/diff.go
@@ -44,11 +44,15 @@ func (d *Diff) GetPatch(do *DiffOptions) (interface{}, error) {
 func (d *Diff) GetDiffStat(dso *DiffStatOptions) (*DiffStatRes, error) {
 
 	params := url.Values{}
-	if dso.Whitespace == true {
+	if dso.FromPullRequestID > 0 {
+		params.Add("from_pullrequest_id", strconv.Itoa(dso.FromPullRequestID))
+	}
+
+	if dso.Whitespace {
 		params.Add("ignore_whitespace", strconv.FormatBool(dso.Whitespace))
 	}
 
-	if dso.Merge == false {
+	if !dso.Merge {
 		params.Add("merge", strconv.FormatBool(dso.Merge))
 	}
 
@@ -56,8 +60,12 @@ func (d *Diff) GetDiffStat(dso *DiffStatOptions) (*DiffStatRes, error) {
 		params.Add("path", dso.Path)
 	}
 
-	if dso.Renames == false {
+	if !dso.Renames {
 		params.Add("renames", strconv.FormatBool(dso.Renames))
+	}
+
+	if dso.Topic {
+		params.Add("topic", strconv.FormatBool(dso.Topic))
 	}
 
 	if dso.PageNum > 0 {


### PR DESCRIPTION
Changes:

Added the additional fields:
- from_pullrequest_id
- topic

to GetDiffStat.

You can see that these fields are used when following a link from a fetched PullRequest (pullRequest.Links.DiffStat.Href).

Here's an example:
```
"diffstat": {
    "href": "https://api.bitbucket.org/2.0/repositories/OWNER/REPO_SLUG/diffstat/SPEC?from_pullrequest_id=2&topic=true"
}
```

In this case SPEC would take the format: `REPO_SLUG:hash`.

An alternative approach would be to add a GetDiffStat on the pullequest interface, and make it specifically for pull request diff stats. Let me know if you'd prefer that. I did it this way provisionally because it was the fastest, although it feels a bit hacky.