### PR TITLE
feat: Added context based execution to POST apis methods

### DIFF
--- a/bitbucket.go
+++ b/bitbucket.go
@@ -1,5 +1,7 @@
 package bitbucket
 
+import "context"
+
 type users interface {
 	Get(username string) (*User, error)
 	Followers(username string) (interface{}, error)
@@ -160,6 +162,12 @@ type RepositoryOptions struct {
 	HasIssues   string `json:"has_issues"`
 	HasWiki     string `json:"has_wiki"`
 	Project     string `json:"project"`
+	ctx         context.Context
+}
+
+func (ro *RepositoryOptions) WithContext(ctx context.Context) *RepositoryOptions {
+	ro.ctx = ctx
+	return ro
 }
 
 type RepositoryForkOptions struct {
@@ -176,6 +184,12 @@ type RepositoryForkOptions struct {
 	HasIssues   string `json:"has_issues"`
 	HasWiki     string `json:"has_wiki"`
 	Project     string `json:"project"`
+	ctx         context.Context
+}
+
+func (fo *RepositoryForkOptions) WithContext(ctx context.Context) *RepositoryForkOptions {
+	fo.ctx = ctx
+	return fo
 }
 
 type RepositoryFilesOptions struct {
@@ -209,6 +223,12 @@ type RepositoryBlobWriteOptions struct {
 	Author        string   `json:"author"`
 	Message       string   `json:"message"`
 	Branch        string   `json:"branch"`
+	ctx           context.Context
+}
+
+func (ro *RepositoryBlobWriteOptions) WithContext(ctx context.Context) *RepositoryBlobWriteOptions {
+	ro.ctx = ctx
+	return ro
 }
 
 // RepositoryRefOptions represents the options for describing a repository's refs (i.e.
@@ -294,6 +314,12 @@ type PullRequestsOptions struct {
 	States            []string `json:"states"`
 	Query             string   `json:"query"`
 	Sort              string   `json:"sort"`
+	ctx               context.Context
+}
+
+func (po *PullRequestsOptions) WithContext(ctx context.Context) *PullRequestsOptions {
+	po.ctx = ctx
+	return po
 }
 
 type PullRequestCommentOptions struct {
@@ -303,6 +329,12 @@ type PullRequestCommentOptions struct {
 	Content       string `json:"content"`
 	CommentId     string `json:"-"`
 	Parent        *int   `json:"parent"`
+	ctx           context.Context
+}
+
+func (pco *PullRequestCommentOptions) WithContext(ctx context.Context) *PullRequestCommentOptions {
+	pco.ctx = ctx
+	return pco
 }
 
 type IssuesOptions struct {
@@ -321,6 +353,12 @@ type IssuesOptions struct {
 	Priority  string   `json:"priority"`
 	Version   string   `json:"version"`
 	Assignee  string   `json:"assignee"`
+	ctx       context.Context
+}
+
+func (io *IssuesOptions) WithContext(ctx context.Context) *IssuesOptions {
+	io.ctx = ctx
+	return io
 }
 
 type IssueCommentsOptions struct {
@@ -352,6 +390,12 @@ type CommitsOptions struct {
 	Exclude     string `json:"exclude"`
 	CommentID   string `json:"comment_id"`
 	Page        *int   `json:"page"`
+	ctx         context.Context
+}
+
+func (cm *CommitsOptions) WithContext(ctx context.Context) *CommitsOptions {
+	cm.ctx = ctx
+	return cm
 }
 
 type CommitStatusOptions struct {
@@ -373,6 +417,12 @@ type BranchRestrictionsOptions struct {
 	FullSlug string            `json:"full_slug"`
 	Name     string            `json:"name"`
 	Value    interface{}       `json:"value"`
+	ctx      context.Context
+}
+
+func (b *BranchRestrictionsOptions) WithContext(ctx context.Context) *BranchRestrictionsOptions {
+	b.ctx = ctx
+	return b
 }
 
 type DiffOptions struct {
@@ -406,6 +456,12 @@ type WebhooksOptions struct {
 	Url         string   `json:"url"`
 	Active      bool     `json:"active"`
 	Events      []string `json:"events"` // EX: {'repo:push','issue:created',..} REF: https://bit.ly/3FjRHHu
+	ctx         context.Context
+}
+
+func (wo *WebhooksOptions) WithContext(ctx context.Context) *WebhooksOptions {
+	wo.ctx = ctx
+	return wo
 }
 
 type RepositoryPipelineOptions struct {
@@ -437,6 +493,12 @@ type RepositoryPipelineVariableOptions struct {
 	Key      string `json:"key"`
 	Value    string `json:"value"`
 	Secured  bool   `json:"secured"`
+	ctx      context.Context
+}
+
+func (rpvo *RepositoryPipelineVariableOptions) WithContext(ctx context.Context) *RepositoryPipelineVariableOptions {
+	rpvo.ctx = ctx
+	return rpvo
 }
 
 type RepositoryPipelineVariableDeleteOptions struct {
@@ -469,6 +531,12 @@ type DownloadsOptions struct {
 	FilePath string `json:"filepath"`
 	FileName string `json:"filename"`
 	Files    []File `json:"files"`
+	ctx      context.Context
+}
+
+func (do *DownloadsOptions) WithContext(ctx context.Context) *DownloadsOptions {
+	do.ctx = ctx
+	return do
 }
 
 type PageRes struct {
@@ -526,6 +594,12 @@ type RepositoryEnvironmentOptions struct {
 	Name            string                          `json:"name"`
 	EnvironmentType RepositoryEnvironmentTypeOption `json:"environment_type"`
 	Rank            int                             `json:"rank"`
+	ctx             context.Context
+}
+
+func (reo *RepositoryEnvironmentOptions) WithContext(ctx context.Context) *RepositoryEnvironmentOptions {
+	reo.ctx = ctx
+	return reo
 }
 
 type RepositoryEnvironmentDeleteOptions struct {
@@ -553,6 +627,12 @@ type RepositoryDeploymentVariableOptions struct {
 	Key         string       `json:"key"`
 	Value       string       `json:"value"`
 	Secured     bool         `json:"secured"`
+	ctx         context.Context
+}
+
+func (rdvo *RepositoryDeploymentVariableOptions) WithContext(ctx context.Context) *RepositoryDeploymentVariableOptions {
+	rdvo.ctx = ctx
+	return rdvo
 }
 
 type RepositoryDeploymentVariableDeleteOptions struct {
@@ -568,4 +648,10 @@ type DeployKeyOptions struct {
 	Id       int    `json:"id"`
 	Label    string `json:"label"`
 	Key      string `json:"key"`
+	ctx      context.Context
+}
+
+func (dk *DeployKeyOptions) WithContext(ctx context.Context) *DeployKeyOptions {
+	dk.ctx = ctx
+	return dk
 }

--- a/branchrestrictions.go
+++ b/branchrestrictions.go
@@ -26,7 +26,7 @@ func (b *BranchRestrictions) Create(bo *BranchRestrictionsOptions) (*BranchRestr
 		return nil, err
 	}
 	urlStr := b.c.requestUrl("/repositories/%s/%s/branch-restrictions", bo.Owner, bo.RepoSlug)
-	response, err := b.c.execute("POST", urlStr, data)
+	response, err := b.c.executeWithContext("POST", urlStr, data, bo.ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -231,6 +231,10 @@ func (c *Client) executeRaw(method string, urlStr string, text string) (io.ReadC
 }
 
 func (c *Client) execute(method string, urlStr string, text string) (interface{}, error) {
+	return c.executeWithContext(method, urlStr, text, context.Background())
+}
+
+func (c *Client) executeWithContext(method string, urlStr string, text string, ctx context.Context) (interface{}, error) {
 	body := strings.NewReader(text)
 	req, err := http.NewRequest(method, urlStr, body)
 	if err != nil {
@@ -239,7 +243,9 @@ func (c *Client) execute(method string, urlStr string, text string) (interface{}
 	if text != "" {
 		req.Header.Set("Content-Type", "application/json")
 	}
-
+	if ctx != nil {
+		req.WithContext(ctx)
+	}
 	c.authenticateRequest(req)
 	result, err := c.doRequest(req, false)
 	if err != nil {
@@ -279,7 +285,7 @@ func (c *Client) executePaginated(method string, urlStr string, text string, pag
 	return result, nil
 }
 
-func (c *Client) executeFileUpload(method string, urlStr string, files []File, filesToDelete []string, params map[string]string) (interface{}, error) {
+func (c *Client) executeFileUpload(method string, urlStr string, files []File, filesToDelete []string, params map[string]string, ctx context.Context) (interface{}, error) {
 	// Prepare a form that you will submit to that URL.
 	var b bytes.Buffer
 	w := multipart.NewWriter(&b)
@@ -326,7 +332,9 @@ func (c *Client) executeFileUpload(method string, urlStr string, files []File, f
 	}
 	// Don't forget to set the content type, this will contain the boundary.
 	req.Header.Set("Content-Type", w.FormDataContentType())
-
+	if ctx != nil {
+		req.WithContext(ctx)
+	}
 	c.authenticateRequest(req)
 	return c.doRequest(req, true)
 

--- a/commits.go
+++ b/commits.go
@@ -42,7 +42,7 @@ func (cm *Commits) GetCommitStatus(cmo *CommitsOptions, commitStatusKey string) 
 
 func (cm *Commits) GiveApprove(cmo *CommitsOptions) (interface{}, error) {
 	urlStr := cm.c.requestUrl("/repositories/%s/%s/commit/%s/approve", cmo.Owner, cmo.RepoSlug, cmo.Revision)
-	return cm.c.execute("POST", urlStr, "")
+	return cm.c.executeWithContext("POST", urlStr, "", cmo.ctx)
 }
 
 func (cm *Commits) RemoveApprove(cmo *CommitsOptions) (interface{}, error) {
@@ -56,7 +56,7 @@ func (cm *Commits) CreateCommitStatus(cmo *CommitsOptions, cso *CommitStatusOpti
 	if err != nil {
 		return nil, err
 	}
-	return cm.c.execute("POST", urlStr, string(data))
+	return cm.c.executeWithContext("POST", urlStr, string(data), cmo.ctx)
 }
 
 func (cm *Commits) buildCommitsQuery(include, exclude string) string {

--- a/deploykeys.go
+++ b/deploykeys.go
@@ -52,7 +52,7 @@ func (dk *DeployKeys) Create(opt *DeployKeyOptions) (*DeployKey, error) {
 		return nil, err
 	}
 	urlStr := dk.c.requestUrl("/repositories/%s/%s/deploy-keys", opt.Owner, opt.RepoSlug)
-	response, err := dk.c.execute("POST", urlStr, data)
+	response, err := dk.c.executeWithContext("POST", urlStr, data, opt.ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/downloads.go
+++ b/downloads.go
@@ -18,7 +18,7 @@ func (dl *Downloads) Create(do *DownloadsOptions) (interface{}, error) {
 			Name: do.FileName,
 		}}
 	}
-	return dl.c.executeFileUpload("POST", urlStr, do.Files, []string{}, make(map[string]string))
+	return dl.c.executeFileUpload("POST", urlStr, do.Files, []string{}, make(map[string]string), do.ctx)
 }
 
 func (dl *Downloads) List(do *DownloadsOptions) (interface{}, error) {

--- a/issues.go
+++ b/issues.go
@@ -65,7 +65,7 @@ func (p *Issues) Create(io *IssuesOptions) (interface{}, error) {
 		return nil, err
 	}
 	urlStr := p.c.requestUrl("/repositories/%s/%s/issues", io.Owner, io.RepoSlug)
-	return p.c.execute("POST", urlStr, data)
+	return p.c.executeWithContext("POST", urlStr, data, io.ctx)
 }
 
 func (p *Issues) GetVote(io *IssuesOptions) (bool, interface{}, error) {
@@ -198,7 +198,7 @@ func (p *Issues) CreateComment(ico *IssueCommentsOptions) (interface{}, error) {
 		return nil, err
 	}
 
-	return p.c.execute("POST", urlStr, data)
+	return p.c.executeWithContext("POST", urlStr, data, ico.ctx)
 }
 
 func (p *Issues) GetComment(ico *IssueCommentsOptions) (interface{}, error) {
@@ -288,7 +288,7 @@ func (p *Issues) CreateChange(ico *IssueChangesOptions) (interface{}, error) {
 
 	fmt.Printf("data %s", data)
 
-	return p.c.execute("POST", url.String(), string(data))
+	return p.c.executeWithContext("POST", url.String(), string(data), ico.ctx)
 }
 
 func (p *Issues) GetChange(ico *IssueChangesOptions) (interface{}, error) {

--- a/project.go
+++ b/project.go
@@ -1,6 +1,7 @@
 package bitbucket
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/mitchellh/mapstructure"
@@ -23,6 +24,12 @@ type ProjectOptions struct {
 	Key         string `json:"key"`
 	Description string `json:"description"`
 	IsPrivate   bool   `json:"is_private"`
+	ctx         context.Context
+}
+
+func (po *ProjectOptions) WithContext(ctx context.Context) *ProjectOptions {
+	po.ctx = ctx
+	return po
 }
 
 func (t *Workspace) GetProject(opt *ProjectOptions) (*Project, error) {
@@ -41,7 +48,7 @@ func (t *Workspace) CreateProject(opt *ProjectOptions) (*Project, error) {
 		return nil, err
 	}
 	urlStr := t.c.requestUrl("/workspaces/%s/projects", opt.Owner)
-	response, err := t.c.execute("POST", urlStr, data)
+	response, err := t.c.executeWithContext("POST", urlStr, data, opt.ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pullrequests.go
+++ b/pullrequests.go
@@ -15,7 +15,7 @@ func (p *PullRequests) Create(po *PullRequestsOptions) (interface{}, error) {
 		return nil, err
 	}
 	urlStr := p.c.requestUrl("/repositories/%s/%s/pullrequests/", po.Owner, po.RepoSlug)
-	return p.c.execute("POST", urlStr, data)
+	return p.c.executeWithContext("POST", urlStr, data, po.ctx)
 }
 
 func (p *PullRequests) Update(po *PullRequestsOptions) (interface{}, error) {
@@ -104,7 +104,7 @@ func (p *PullRequests) Merge(po *PullRequestsOptions) (interface{}, error) {
 		return nil, err
 	}
 	urlStr := p.c.GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID + "/merge"
-	return p.c.execute("POST", urlStr, data)
+	return p.c.executeWithContext("POST", urlStr, data, po.ctx)
 }
 
 func (p *PullRequests) Decline(po *PullRequestsOptions) (interface{}, error) {
@@ -113,12 +113,12 @@ func (p *PullRequests) Decline(po *PullRequestsOptions) (interface{}, error) {
 		return nil, err
 	}
 	urlStr := p.c.GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID + "/decline"
-	return p.c.execute("POST", urlStr, data)
+	return p.c.executeWithContext("POST", urlStr, data, po.ctx)
 }
 
 func (p *PullRequests) Approve(po *PullRequestsOptions) (interface{}, error) {
 	urlStr := p.c.GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID + "/approve"
-	return p.c.execute("POST", urlStr, "")
+	return p.c.executeWithContext("POST", urlStr, "", po.ctx)
 }
 
 func (p *PullRequests) UnApprove(po *PullRequestsOptions) (interface{}, error) {
@@ -128,7 +128,7 @@ func (p *PullRequests) UnApprove(po *PullRequestsOptions) (interface{}, error) {
 
 func (p *PullRequests) RequestChanges(po *PullRequestsOptions) (interface{}, error) {
 	urlStr := p.c.GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID + "/request-changes"
-	return p.c.execute("POST", urlStr, "")
+	return p.c.executeWithContext("POST", urlStr, "", po.ctx)
 }
 
 func (p *PullRequests) UnRequestChanges(po *PullRequestsOptions) (interface{}, error) {
@@ -143,7 +143,7 @@ func (p *PullRequests) AddComment(co *PullRequestCommentOptions) (interface{}, e
 	}
 
 	urlStr := p.c.requestUrl("/repositories/%s/%s/pullrequests/%s/comments", co.Owner, co.RepoSlug, co.PullRequestID)
-	return p.c.execute("POST", urlStr, data)
+	return p.c.executeWithContext("POST", urlStr, data, co.ctx)
 }
 
 func (p *PullRequests) UpdateComment(co *PullRequestCommentOptions) (interface{}, error) {

--- a/repository.go
+++ b/repository.go
@@ -200,7 +200,6 @@ type DefaultReviewer struct {
 	Links       map[string]map[string]string
 }
 
-
 type DefaultReviewers struct {
 	Page             int
 	Pagelen          int
@@ -216,11 +215,11 @@ type EffectiveDefaultReviewer struct {
 }
 
 type EffectiveDefaultReviewers struct {
-	Page             int
-	Pagelen          int
-	MaxDepth         int
-	Size             int
-	Next             string
+	Page                      int
+	Pagelen                   int
+	MaxDepth                  int
+	Size                      int
+	Next                      string
 	EffectiveDefaultReviewers []EffectiveDefaultReviewer
 }
 
@@ -277,7 +276,7 @@ func (r *Repository) Create(ro *RepositoryOptions) (*Repository, error) {
 		return nil, err
 	}
 	urlStr := r.c.requestUrl("/repositories/%s/%s", ro.Owner, ro.RepoSlug)
-	response, err := r.c.execute("POST", urlStr, data)
+	response, err := r.c.executeWithContext("POST", urlStr, data, ro.ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -291,7 +290,7 @@ func (r *Repository) Fork(fo *RepositoryForkOptions) (*Repository, error) {
 		return nil, err
 	}
 	urlStr := r.c.requestUrl("/repositories/%s/%s/forks", fo.FromOwner, fo.FromSlug)
-	response, err := r.c.execute("POST", urlStr, data)
+	response, err := r.c.executeWithContext("POST", urlStr, data, fo.ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -399,7 +398,7 @@ func (r *Repository) WriteFileBlob(ro *RepositoryBlobWriteOptions) error {
 
 	urlStr := r.c.requestUrl("/repositories/%s/%s/src", ro.Owner, ro.RepoSlug)
 
-	_, err := r.c.executeFileUpload("POST", urlStr, ro.Files, ro.FilesToDelete, m)
+	_, err := r.c.executeFileUpload("POST", urlStr, ro.Files, ro.FilesToDelete, m, ro.ctx)
 	return err
 }
 
@@ -727,7 +726,7 @@ func (r *Repository) AddPipelineVariable(rpvo *RepositoryPipelineVariableOptions
 	}
 	urlStr := r.c.requestUrl("/repositories/%s/%s/pipelines_config/variables/", rpvo.Owner, rpvo.RepoSlug)
 
-	response, err := r.c.execute("POST", urlStr, data)
+	response, err := r.c.executeWithContext("POST", urlStr, data, rpvo.ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -839,7 +838,7 @@ func (r *Repository) AddEnvironment(opt *RepositoryEnvironmentOptions) (*Environ
 		return nil, err
 	}
 	urlStr := r.c.requestUrl("/repositories/%s/%s/environments/", opt.Owner, opt.RepoSlug)
-	res, err := r.c.execute("POST", urlStr, body)
+	res, err := r.c.executeWithContext("POST", urlStr, body, opt.ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -904,7 +903,7 @@ func (r *Repository) AddDeploymentVariable(opt *RepositoryDeploymentVariableOpti
 	}
 	urlStr := r.c.requestUrl("/repositories/%s/%s/deployments_config/environments/%s/variables", opt.Owner, opt.RepoSlug, opt.Environment.Uuid)
 
-	response, err := r.c.execute("POST", urlStr, body)
+	response, err := r.c.executeWithContext("POST", urlStr, body, opt.ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1796,7 +1795,6 @@ func decodeDefaultReviewers(response interface{}) (*DefaultReviewers, error) {
 	return &defaultReviewerVariables, nil
 }
 
-
 func decodeEffectiveDefaultReviewers(response interface{}) (*EffectiveDefaultReviewers, error) {
 	responseMap := response.(map[string]interface{})
 	values := responseMap["values"].([]interface{})
@@ -1833,11 +1831,11 @@ func decodeEffectiveDefaultReviewers(response interface{}) (*EffectiveDefaultRev
 	}
 
 	defaultReviewerVariables := EffectiveDefaultReviewers{
-		Page:             int(page),
-		Pagelen:          int(pagelen),
-		MaxDepth:         int(max_depth),
-		Size:             int(size),
-		Next:             next,
+		Page:                      int(page),
+		Pagelen:                   int(pagelen),
+		MaxDepth:                  int(max_depth),
+		Size:                      int(size),
+		Next:                      next,
 		EffectiveDefaultReviewers: variables,
 	}
 	return &defaultReviewerVariables, nil

--- a/webhooks.go
+++ b/webhooks.go
@@ -97,7 +97,7 @@ func (r *Webhooks) Create(ro *WebhooksOptions) (*Webhook, error) {
 		return nil, err
 	}
 	urlStr := r.c.requestUrl("/repositories/%s/%s/hooks", ro.Owner, ro.RepoSlug)
-	response, err := r.c.execute("POST", urlStr, data)
+	response, err := r.c.executeWithContext("POST", urlStr, data, ro.ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently the Post APIs has no context binding, which restricts us to gracefully shutdown the POST api.
1. Added internal filed ctx to All POST api based methods
2. Method to update ctx in the method request.

Fixes https://github.com/ktrysmt/go-bitbucket/issues/286