### PR TITLE
Add missing query parameters to GetDiff

### DIFF
--- a/bitbucket.go
+++ b/bitbucket.go
@@ -426,9 +426,16 @@ func (b *BranchRestrictionsOptions) WithContext(ctx context.Context) *BranchRest
 }
 
 type DiffOptions struct {
-	Owner    string `json:"owner"`
-	RepoSlug string `json:"repo_slug"`
-	Spec     string `json:"spec"`
+	Owner             string `json:"owner"`
+	RepoSlug          string `json:"repo_slug"`
+	Spec              string `json:"spec"`
+	Context           int    `json:"context"`
+	Path              string `json:"path"`
+	FromPullRequestID int    `json:"from_pullrequest_id"`
+	Whitespace        bool   `json:"ignore_whitespace"`
+	Binary            bool   `json:"binary"`
+	Renames           bool   `json:"renames"`
+	Topic             bool   `json:"topic"`
 }
 
 type DiffStatOptions struct {
@@ -437,14 +444,15 @@ type DiffStatOptions struct {
 	Spec              string `json:"spec"`
 	FromPullRequestID int    `json:"from_pullrequest_id"`
 	Whitespace        bool   `json:"ignore_whitespace"`
-	Merge             bool   `json:"merge"`
-	Path              string `json:"path"`
-	Renames           bool   `json:"renames"`
-	Topic             bool   `json:"topic"`
-	PageNum           int    `json:"page"`
-	Pagelen           int    `json:"pagelen"`
-	MaxDepth          int    `json:"max_depth"`
-	Fields            []string
+	// Deprecated: Merge is deprecated use Topic
+	Merge    bool   `json:"merge"`
+	Path     string `json:"path"`
+	Renames  bool   `json:"renames"`
+	Topic    bool   `json:"topic"`
+	PageNum  int    `json:"page"`
+	Pagelen  int    `json:"pagelen"`
+	MaxDepth int    `json:"max_depth"`
+	Fields   []string
 }
 
 type WebhooksOptions struct {

--- a/diff.go
+++ b/diff.go
@@ -32,8 +32,38 @@ type DiffStat struct {
 }
 
 func (d *Diff) GetDiff(do *DiffOptions) (interface{}, error) {
-	urlStr := d.c.requestUrl("/repositories/%s/%s/diff/%s", do.Owner, do.RepoSlug, do.Spec)
-	return d.c.executeRaw("GET", urlStr, "diff")
+
+	params := url.Values{}
+	if do.FromPullRequestID > 0 {
+		params.Add("from_pullrequest_id", strconv.Itoa(do.FromPullRequestID))
+	}
+
+	if do.Whitespace {
+		params.Add("ignore_whitespace", strconv.FormatBool(do.Whitespace))
+	}
+
+	if do.Context > 0 {
+		params.Add("context", strconv.Itoa(do.Context))
+	}
+
+	if do.Path != "" {
+		params.Add("path", do.Path)
+	}
+
+	if !do.Binary {
+		params.Add("binary", strconv.FormatBool(do.Binary))
+	}
+
+	if !do.Renames {
+		params.Add("renames", strconv.FormatBool(do.Renames))
+	}
+
+	if do.Topic {
+		params.Add("topic", strconv.FormatBool(do.Topic))
+	}
+
+	urlStr := d.c.requestUrl("/repositories/%s/%s/diff/%s?%s", do.Owner, do.RepoSlug, do.Spec, params.Encode())
+	return d.c.executeRaw("GET", urlStr, "")
 }
 
 func (d *Diff) GetPatch(do *DiffOptions) (interface{}, error) {


### PR DESCRIPTION
Changes:

Added the additional fields:

- context
- path
- from_pullrequest_id
- ignore_whitespace
- binary
- renames
- topic

to GetDiff.

Justified by [the documentation page](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-commits/#api-repositories-workspace-repo-slug-diff-spec-get), and adding `from_pullrequest_id` as it appears in `pullRequest.Links.Diff.Href`:
```
"diff": {
    "href": "https://api.bitbucket.org/2.0/repositories/OWNER/REPO_SLUG/diff/SPEC?from_pullrequest_id=3&topic=true"
}
```

When using GetDiff with `from_pullrequest_id` (as also happens with GetDiffStat) the SPEC would follow the format: `REPO_SLUG:hash`.

NOTE: I am aware that the `DiffOptions` type is also used as a parameter to GetPatch, [which does not seem to support all these query parameters](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-commits/#api-repositories-workspace-repo-slug-patch-spec-get). I was tempted to create a new type:
```
type PatchOptions struct {
	Owner             string `json:"owner"`
	RepoSlug          string `json:"repo_slug"`
	Spec              string `json:"spec"`
}
```
but replacing the current parameter in `GetPatch` with this new type would break backwards compatibility with any current consumers of this library.

So I just mention it in case you want to do that separately in a future version change ;)