### PR TITLE
Add Draft Pull request option

### DIFF
--- a/bitbucket.go
+++ b/bitbucket.go
@@ -314,6 +314,7 @@ type PullRequestsOptions struct {
 	States            []string `json:"states"`
 	Query             string   `json:"query"`
 	Sort              string   `json:"sort"`
+	Draft             bool     `json:"draft"`
 	ctx               context.Context
 }
 
@@ -665,8 +666,8 @@ func (dk *DeployKeyOptions) WithContext(ctx context.Context) *DeployKeyOptions {
 }
 
 type SSHKeyOptions struct {
-	Owner    string `json:"owner"`
-	Uuid     string `json:"uuid"`
-	Label    string `json:"label"`
-	Key      string `json:"key"`
+	Owner string `json:"owner"`
+	Uuid  string `json:"uuid"`
+	Label string `json:"label"`
+	Key   string `json:"key"`
 }

--- a/pullrequests.go
+++ b/pullrequests.go
@@ -242,8 +242,12 @@ func (p *PullRequests) buildPullRequestBody(po *PullRequestsOptions) (string, er
 		body["message"] = po.Message
 	}
 
-	if po.CloseSourceBranch == true || po.CloseSourceBranch == false {
+	if po.CloseSourceBranch || !po.CloseSourceBranch {
 		body["close_source_branch"] = po.CloseSourceBranch
+	}
+
+	if po.Draft {
+		body["draft"] = true
 	}
 
 	data, err := json.Marshal(body)


### PR DESCRIPTION
New feature in bitbucket allows for `draft: true` to be supplied when creating the PR to mark it as a DRAFT Pull request.
<img width="906" alt="image" src="https://github.com/user-attachments/assets/57947135-f1cd-4b1a-8817-5ba7ad7c6e28" />
