### PR TITLE
Added *http.Response in the Response struct

### DIFF
--- a/client.go
+++ b/client.go
@@ -193,7 +193,7 @@ func injectClient(a *auth) *Client {
 		DeployKeys:         &DeployKeys{c: c},
 	}
 	c.Users = &Users{
-		c:       c,
+	c:       c,
 		SSHKeys: &SSHKeys{c: c},
 	}
 	c.User = &User{c: c}

--- a/client.go
+++ b/client.go
@@ -193,7 +193,7 @@ func injectClient(a *auth) *Client {
 		DeployKeys:         &DeployKeys{c: c},
 	}
 	c.Users = &Users{
-	c:       c,
+		c: c,
 		SSHKeys: &SSHKeys{c: c},
 	}
 	c.User = &User{c: c}

--- a/client.go
+++ b/client.go
@@ -62,7 +62,7 @@ type auth struct {
 }
 
 type Response struct {
-	*http.Response
+	*http.Response `json:"-"`
 	Size     int           `json:"size"`
 	Page     int           `json:"page"`
 	Pagelen  int           `json:"pagelen"`

--- a/client.go
+++ b/client.go
@@ -62,6 +62,7 @@ type auth struct {
 }
 
 type Response struct {
+	*http.Response
 	Size     int           `json:"size"`
 	Page     int           `json:"page"`
 	Pagelen  int           `json:"pagelen"`
@@ -192,8 +193,8 @@ func injectClient(a *auth) *Client {
 		DeployKeys:         &DeployKeys{c: c},
 	}
 	c.Users = &Users{
-		c: c,
-		SSHKeys:  &SSHKeys{c: c},
+		c:       c,
+		SSHKeys: &SSHKeys{c: c},
 	}
 	c.User = &User{c: c}
 	c.Teams = &Teams{c: c}


### PR DESCRIPTION
## 📦 Embed `*http.Response` in `Response` Struct for Extended Access to Raw HTTP Metadata

### Summary

This PR enhances the `Response` struct in the Bitbucket client by embedding the `*http.Response` type. This change improves the client's ability to expose and inspect raw HTTP metadata such as status code, headers, and cookies alongside the deserialized Bitbucket API response.

---

### ✅ What's Changed

- Embedded `*http.Response` into the `Response` struct:
  ```go
  type Response struct {
      *http.Response
      Size     int           `json:"size"`
      Page     int           `json:"page"`
      Pagelen  int           `json:"pagelen"`
      Next     string        `json:"next"`
      Previous string        `json:"previous"`
      Values   []interface{} `json:"values"`
  }
