### PR TITLE
Fix list branch query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 .idea
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor
+.idea

--- a/repository.go
+++ b/repository.go
@@ -441,6 +441,10 @@ func (r *Repository) ListRefs(rbo *RepositoryRefOptions) (*RepositoryRefs, error
 	return decodeRepositoryRefs(bodyString)
 }
 
+// ListBranches gets all branches in the Bitbucket repository and returns them as a RepositoryBranches.
+// You can pass query parameter to filter branches by name.
+//
+// Bitbucket API docs: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-refs/#api-repositories-workspace-repo-slug-refs-get
 func (r *Repository) ListBranches(rbo *RepositoryBranchOptions) (*RepositoryBranches, error) {
 	params := url.Values{}
 

--- a/repository.go
+++ b/repository.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/url"
 	"path"
@@ -443,8 +444,11 @@ func (r *Repository) ListRefs(rbo *RepositoryRefOptions) (*RepositoryRefs, error
 func (r *Repository) ListBranches(rbo *RepositoryBranchOptions) (*RepositoryBranches, error) {
 
 	params := url.Values{}
+
 	if rbo.Query != "" {
-		params.Add("q", rbo.Query)
+		// https://developer.atlassian.com/cloud/bitbucket/rest/intro/#operators
+		query := fmt.Sprintf("name ~ \"%s\"", rbo.Query)
+		params.Set("q", query)
 	}
 
 	if rbo.Sort != "" {
@@ -468,7 +472,7 @@ func (r *Repository) ListBranches(rbo *RepositoryBranchOptions) (*RepositoryBran
 	if err != nil {
 		return nil, err
 	}
-	bodyBytes, err := ioutil.ReadAll(response)
+	bodyBytes, err := io.ReadAll(response)
 	if err != nil {
 		return nil, err
 	}

--- a/repository.go
+++ b/repository.go
@@ -442,7 +442,6 @@ func (r *Repository) ListRefs(rbo *RepositoryRefOptions) (*RepositoryRefs, error
 }
 
 func (r *Repository) ListBranches(rbo *RepositoryBranchOptions) (*RepositoryBranches, error) {
-
 	params := url.Values{}
 
 	if rbo.Query != "" {
@@ -476,8 +475,8 @@ func (r *Repository) ListBranches(rbo *RepositoryBranchOptions) (*RepositoryBran
 	if err != nil {
 		return nil, err
 	}
-	bodyString := string(bodyBytes)
-	return decodeRepositoryBranches(bodyString)
+
+	return decodeRepositoryBranches(string(bodyBytes))
 }
 
 func (r *Repository) GetBranch(rbo *RepositoryBranchOptions) (*RepositoryBranch, error) {

--- a/tests/repository_test.go
+++ b/tests/repository_test.go
@@ -750,9 +750,12 @@ func TestListBranches(t *testing.T) {
 
 	response, err := client.Repositories.Repository.ListBranches(opts)
 	if err != nil {
-		t.Error(err)
+		t.Fatalf("ListBranches() returned an error: %v", err)
 	}
 	if response == nil {
-		t.Error("Cannot get list branches")
+		t.Fatal("Cannot get list branches")
+	}
+	if response.Size == 0 {
+		t.Fatalf("Expected to find at least one branch for query '%s', but found none", opts.Query)
 	}
 }

--- a/tests/repository_test.go
+++ b/tests/repository_test.go
@@ -737,3 +737,22 @@ func TestSetRepositoryUserPermissions(t *testing.T) {
 	}
 
 }
+
+func TestListBranches(t *testing.T) {
+	client := setup(t)
+
+	opts := &bitbucket.RepositoryBranchOptions{
+		Owner:    owner,
+		RepoSlug: repo,
+		Pagelen:  10,
+		Query:    "develop",
+	}
+
+	response, err := client.Repositories.Repository.ListBranches(opts)
+	if err != nil {
+		t.Error(err)
+	}
+	if response == nil {
+		t.Error("Cannot get list branches")
+	}
+}


### PR DESCRIPTION
Refers to #312.
* Fixed incorrect handling of the `q` (query) parameter in the `ListBranches` method.  
* Added unit tests and documentation for `ListBranches`.  
* Automatic pagination via `executePaginated`  is not yet implemented. Supporting it requires refactoring the `decodeRepositoryBranches` method to use a different format. I can include these changes in this PR if that’s fine.