### PR TITLE
Fix deprecated `GET /2.0/workspaces` endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
-module github.com/ktrysmt/go-bitbucket
+module github.com/trufflesecurity/go-bitbucket
 
 go 1.25.0
 
 // You can uncomment this for local testing and development.
 // Ref: https://thewebivore.com/using-replace-in-go-mod-to-point-to-your-local-module/
 //replace (
-//	github.com/ktrysmt/go-bitbucket => ./
-//	github.com/ktrysmt/go-bitbucket/tests => ./tests
+//	github.com/trufflesecurity/go-bitbucket => ./
+//	github.com/trufflesecurity/go-bitbucket/tests => ./tests
 //)
 
 require (

--- a/mock_tests/pullrequests_mock_test.go
+++ b/mock_tests/pullrequests_mock_test.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"testing"
 
-	go_bitbucket "github.com/ktrysmt/go-bitbucket"
-	"github.com/ktrysmt/go-bitbucket/mockgen"
+	go_bitbucket "github.com/trufflesecurity/go-bitbucket"
+	"github.com/trufflesecurity/go-bitbucket/mockgen"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )

--- a/mock_tests/repository_mock_test.go
+++ b/mock_tests/repository_mock_test.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"testing"
 
-	go_bitbucket "github.com/ktrysmt/go-bitbucket"
-	"github.com/ktrysmt/go-bitbucket/mockgen"
+	go_bitbucket "github.com/trufflesecurity/go-bitbucket"
+	"github.com/trufflesecurity/go-bitbucket/mockgen"
 	"github.com/stretchr/testify/assert"
 
 	"go.uber.org/mock/gomock"

--- a/mockgen/bitbucket_mockgen.go
+++ b/mockgen/bitbucket_mockgen.go
@@ -12,7 +12,7 @@ package mockgen
 import (
 	reflect "reflect"
 
-	bitbucket "github.com/ktrysmt/go-bitbucket"
+	bitbucket "github.com/trufflesecurity/go-bitbucket"
 	gomock "go.uber.org/mock/gomock"
 )
 

--- a/tests/branchrestrictions_test.go
+++ b/tests/branchrestrictions_test.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/ktrysmt/go-bitbucket"
+	"github.com/trufflesecurity/go-bitbucket"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/ktrysmt/go-bitbucket"
+	"github.com/trufflesecurity/go-bitbucket"
 )
 
 const (

--- a/tests/deploykeys_test.go
+++ b/tests/deploykeys_test.go
@@ -7,7 +7,7 @@ import (
 
 	_ "github.com/k0kubun/pp"
 
-	"github.com/ktrysmt/go-bitbucket"
+	"github.com/trufflesecurity/go-bitbucket"
 )
 
 func TestDeployKey(t *testing.T) {

--- a/tests/diff_test.go
+++ b/tests/diff_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/k0kubun/pp"
-	"github.com/ktrysmt/go-bitbucket"
+	"github.com/trufflesecurity/go-bitbucket"
 )
 
 func TestDiff(t *testing.T) {

--- a/tests/environment_test.go
+++ b/tests/environment_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	_ "github.com/k0kubun/pp"
-	"github.com/ktrysmt/go-bitbucket"
+	"github.com/trufflesecurity/go-bitbucket"
 )
 
 func TestListEnvironments(t *testing.T) {

--- a/tests/list_test.go
+++ b/tests/list_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ktrysmt/go-bitbucket"
+	"github.com/trufflesecurity/go-bitbucket"
 )
 
 func TestList(t *testing.T) {

--- a/tests/project_test.go
+++ b/tests/project_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ktrysmt/go-bitbucket"
+	"github.com/trufflesecurity/go-bitbucket"
 )
 
 func getClient(t *testing.T) *bitbucket.Client {

--- a/tests/repositories_test.go
+++ b/tests/repositories_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ktrysmt/go-bitbucket"
+	"github.com/trufflesecurity/go-bitbucket"
 )
 
 func TestListForAccount(t *testing.T) {

--- a/tests/repository_access_token_test.go
+++ b/tests/repository_access_token_test.go
@@ -3,7 +3,7 @@ package tests
 import (
 	"testing"
 
-	"github.com/ktrysmt/go-bitbucket"
+	"github.com/trufflesecurity/go-bitbucket"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/tests/repository_test.go
+++ b/tests/repository_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	_ "github.com/k0kubun/pp"
-	"github.com/ktrysmt/go-bitbucket"
+	"github.com/trufflesecurity/go-bitbucket"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/tests/ssh_test.go
+++ b/tests/ssh_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ktrysmt/go-bitbucket"
+	"github.com/trufflesecurity/go-bitbucket"
 )
 
 func TestUserSSHKey(t *testing.T) {

--- a/tests/test_setup.go
+++ b/tests/test_setup.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ktrysmt/go-bitbucket"
+	"github.com/trufflesecurity/go-bitbucket"
 )
 
 var (

--- a/tests/user_test.go
+++ b/tests/user_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ktrysmt/go-bitbucket"
+	"github.com/trufflesecurity/go-bitbucket"
 )
 
 func TestProfile(t *testing.T) {

--- a/tests/variable_test.go
+++ b/tests/variable_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	_ "github.com/k0kubun/pp"
-	"github.com/ktrysmt/go-bitbucket"
+	"github.com/trufflesecurity/go-bitbucket"
 )
 
 func TestEndToEndDeploymentVariables(t *testing.T) {

--- a/tests/webhooks_test.go
+++ b/tests/webhooks_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ktrysmt/go-bitbucket"
+	"github.com/trufflesecurity/go-bitbucket"
 )
 
 func TestWebhook(t *testing.T) {

--- a/tests/workspace_test.go
+++ b/tests/workspace_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ktrysmt/go-bitbucket"
+	"github.com/trufflesecurity/go-bitbucket"
 )
 
 func getBitbucketClient(t *testing.T) *bitbucket.Client {

--- a/workspaces.go
+++ b/workspaces.go
@@ -135,23 +135,34 @@ func decodeWorkspace(workspace interface{}) (*Workspace, error) {
 		return nil, DecodeError(workspaceResponseMap)
 	}
 
-	// /user/workspaces returns a permission wrapper with the workspace nested
-	// under a "workspace" key. Extract it so decoding works for both endpoints.
-	if nested, ok := workspaceResponseMap["workspace"].(map[string]interface{}); ok {
-		workspaceResponseMap = nested
-	}
-
 	err := mapstructure.Decode(workspaceResponseMap, &workspaceEntry)
 	return &workspaceEntry, err
 }
 
 func decodeWorkspaceList(workspaceResponse interface{}) (*WorkspaceList, error) {
 	workspaceResponseMap := workspaceResponse.(map[string]interface{})
-	workspaceMapList := workspaceResponseMap["values"].([]interface{})
+	valuesRaw, ok := workspaceResponseMap["values"]
+	if !ok || valuesRaw == nil {
+		return &WorkspaceList{}, nil
+	}
+	workspaceMapList, ok := valuesRaw.([]interface{})
+	if !ok {
+		return &WorkspaceList{}, nil
+	}
 
 	var workspaces []Workspace
-	for _, workspaceMap := range workspaceMapList {
-		workspaceEntry, err := decodeWorkspace(workspaceMap)
+	for _, item := range workspaceMapList {
+		// GET /user/workspaces returns workspace_access objects; the workspace
+		// is nested under the "workspace" key.
+		itemMap, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		nested, ok := itemMap["workspace"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		workspaceEntry, err := decodeWorkspace(nested)
 		if err != nil {
 			return nil, err
 		}

--- a/workspaces.go
+++ b/workspaces.go
@@ -135,20 +135,13 @@ func decodeWorkspace(workspace interface{}) (*Workspace, error) {
 		return nil, DecodeError(workspaceResponseMap)
 	}
 
-	err := mapstructure.Decode(workspaceResponseMap, &workspaceEntry)
+	err := mapstructure.Decode(workspace, &workspaceEntry)
 	return &workspaceEntry, err
 }
 
 func decodeWorkspaceList(workspaceResponse interface{}) (*WorkspaceList, error) {
 	workspaceResponseMap := workspaceResponse.(map[string]interface{})
-	valuesRaw, ok := workspaceResponseMap["values"]
-	if !ok || valuesRaw == nil {
-		return &WorkspaceList{}, nil
-	}
-	workspaceMapList, ok := valuesRaw.([]interface{})
-	if !ok {
-		return &WorkspaceList{}, nil
-	}
+	workspaceMapList := workspaceResponseMap["values"].([]interface{})
 
 	var workspaces []Workspace
 	for _, item := range workspaceMapList {

--- a/workspaces.go
+++ b/workspaces.go
@@ -71,7 +71,7 @@ func (t *Permission) GetUserPermissionsByUuid(organization, member string) (*Per
 }
 
 func (t *Workspace) List() (*WorkspaceList, error) {
-	urlStr := t.c.requestUrl("/workspaces")
+	urlStr := t.c.requestUrl("/user/workspaces")
 	response, err := t.c.executePaginated("GET", urlStr, "", nil)
 	if err != nil {
 		return nil, err
@@ -135,7 +135,13 @@ func decodeWorkspace(workspace interface{}) (*Workspace, error) {
 		return nil, DecodeError(workspaceResponseMap)
 	}
 
-	err := mapstructure.Decode(workspace, &workspaceEntry)
+	// /user/workspaces returns a permission wrapper with the workspace nested
+	// under a "workspace" key. Extract it so decoding works for both endpoints.
+	if nested, ok := workspaceResponseMap["workspace"].(map[string]interface{}); ok {
+		workspaceResponseMap = nested
+	}
+
+	err := mapstructure.Decode(workspaceResponseMap, &workspaceEntry)
 	return &workspaceEntry, err
 }
 


### PR DESCRIPTION
Bitbucket [announced end-of-life for cross-workspace APIs](https://community.atlassian.com/forums/Bitbucket-articles/Bitbucket-Cloud-Announcing-End-of-Life-for-Cross-Workspace-APIs/ba-p/3196105), with brownout windows beginning March 23, 2026 and permanent removal on April 14, 2026. `GET /2.0/workspaces` was returning `410 Gone` during brownout windows.

### Changes

**`workspaces.go`**

- `Workspace.List()` now calls `GET /2.0/user/workspaces` instead of the deprecated `GET /2.0/workspaces`
- `decodeWorkspaceList()` updated to unwrap the `workspace_access` envelope returned by the new endpoint — each item in `values` wraps the workspace object under a nested `"workspace"` key, which is now extracted before passing to `decodeWorkspace()`

**`go.mod` / imports**

- Module name changed from `github.com/ktrysmt/go-bitbucket` to `github.com/trufflesecurity/go-bitbucket` to reflect the fork
- All internal imports updated accordingly
