### PR TITLE
fix: replace deprecated /2.0/workspaces with /2.0/user/workspaces

### DIFF
--- a/workspaces.go
+++ b/workspaces.go
@@ -71,7 +71,7 @@ func (t *Permission) GetUserPermissionsByUuid(organization, member string) (*Per
 }
 
 func (t *Workspace) List() (*WorkspaceList, error) {
-	urlStr := t.c.requestUrl("/workspaces")
+	urlStr := t.c.requestUrl("/user/workspaces")
 	response, err := t.c.executePaginated("GET", urlStr, "", nil)
 	if err != nil {
 		return nil, err
@@ -144,8 +144,18 @@ func decodeWorkspaceList(workspaceResponse interface{}) (*WorkspaceList, error) 
 	workspaceMapList := workspaceResponseMap["values"].([]interface{})
 
 	var workspaces []Workspace
-	for _, workspaceMap := range workspaceMapList {
-		workspaceEntry, err := decodeWorkspace(workspaceMap)
+	for _, item := range workspaceMapList {
+		// GET /2.0/user/workspaces returns workspace_access objects;
+		// the workspace is nested under the "workspace" key.
+		itemMap, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		nested, ok := itemMap["workspace"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		workspaceEntry, err := decodeWorkspace(nested)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary
- Bitbucket Cloud fully removed `GET /2.0/workspaces` on 2026-04-14 ([CHANGE-2770](https://developer.atlassian.com/cloud/bitbucket/changelog#CHANGE-2770)), so `Workspace.List()` currently fails for every caller.
- Switch the endpoint to `GET /2.0/user/workspaces` and unwrap the `workspace_access` envelope (`values[].workspace`) in `decodeWorkspaceList`.

Closes #357.

The `workspaces.go` change here is the same approach taken in #355; this PR pulls just that portion so the upstream module path is preserved. Credit to @mustansir14 via `Co-Authored-By`.

## Test plan
- [x] `go build ./...` passes (the pre-existing `go vet` warning on `bitbucket.go:272-274` about duplicate `uuid` json tag is unrelated to this change).
- [ ] Verify against a real account that `Workspace.List()` returns the expected workspaces (requires `BITBUCKET_USERNAME` / `BITBUCKET_PASSWORD`; cannot be run in this environment).

## References
- Issue: https://github.com/ktrysmt/go-bitbucket/issues/357
- Atlassian announcement: https://community.atlassian.com/forums/Bitbucket-articles/Bitbucket-Cloud-Announcing-End-of-Life-for-Cross-Workspace-APIs/ba-p/3196105
- New endpoint docs: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-workspaces/#api-user-workspaces-get