### PR TITLE
fix: attach client to *Repository returned from API calls (#347)

### DIFF
--- a/repositories.go
+++ b/repositories.go
@@ -55,7 +55,12 @@ func (r *Repositories) ListForAccount(ro *RepositoriesOptions) (*RepositoriesRes
 	if err != nil {
 		return nil, err
 	}
-	return decodeRepositories(repos)
+	res, err := decodeRepositories(repos)
+	if err != nil {
+		return nil, err
+	}
+	r.attachClientToItems(res)
+	return res, nil
 }
 
 // Deprecated: Use ListForAccount instead
@@ -71,7 +76,12 @@ func (r *Repositories) ListProject(ro *RepositoriesOptions) (*RepositoriesRes, e
 	if err != nil {
 		return nil, err
 	}
-	return decodeRepositories(repos)
+	res, err := decodeRepositories(repos)
+	if err != nil {
+		return nil, err
+	}
+	r.attachClientToItems(res)
+	return res, nil
 }
 
 func (r *Repositories) ListPublic() (*RepositoriesRes, error) {
@@ -80,7 +90,21 @@ func (r *Repositories) ListPublic() (*RepositoriesRes, error) {
 	if err != nil {
 		return nil, err
 	}
-	return decodeRepositories(repos)
+	res, err := decodeRepositories(repos)
+	if err != nil {
+		return nil, err
+	}
+	r.attachClientToItems(res)
+	return res, nil
+}
+
+func (r *Repositories) attachClientToItems(res *RepositoriesRes) {
+	if res == nil {
+		return
+	}
+	for i := range res.Items {
+		res.Items[i].attachClient(r.c)
+	}
 }
 
 func decodeRepositories(reposResponse interface{}) (*RepositoriesRes, error) {

--- a/repository.go
+++ b/repository.go
@@ -270,6 +270,19 @@ type UserPermissions struct {
 
 var stringToTimeHookFunc = mapstructure.StringToTimeHookFunc("2006-01-02T15:04:05.000000+00:00")
 
+// attachClient wires the API client onto the Repository (and its Parent, if any)
+// so that methods invoked on the returned value do not panic with a nil client.
+// See https://github.com/ktrysmt/go-bitbucket/issues/347.
+func (r *Repository) attachClient(c *Client) {
+	if r == nil {
+		return
+	}
+	r.c = c
+	if r.Parent != nil {
+		r.Parent.attachClient(c)
+	}
+}
+
 func (r *Repository) Create(ro *RepositoryOptions) (*Repository, error) {
 	data, err := r.buildRepositoryBody(ro)
 	if err != nil {
@@ -281,7 +294,12 @@ func (r *Repository) Create(ro *RepositoryOptions) (*Repository, error) {
 		return nil, err
 	}
 
-	return decodeRepository(response)
+	repo, err := decodeRepository(response)
+	if err != nil {
+		return nil, err
+	}
+	repo.attachClient(r.c)
+	return repo, nil
 }
 
 func (r *Repository) Fork(fo *RepositoryForkOptions) (*Repository, error) {
@@ -295,7 +313,12 @@ func (r *Repository) Fork(fo *RepositoryForkOptions) (*Repository, error) {
 		return nil, err
 	}
 
-	return decodeRepository(response)
+	repo, err := decodeRepository(response)
+	if err != nil {
+		return nil, err
+	}
+	repo.attachClient(r.c)
+	return repo, nil
 }
 
 func (r *Repository) Get(ro *RepositoryOptions) (*Repository, error) {
@@ -305,7 +328,12 @@ func (r *Repository) Get(ro *RepositoryOptions) (*Repository, error) {
 		return nil, err
 	}
 
-	return decodeRepository(response)
+	repo, err := decodeRepository(response)
+	if err != nil {
+		return nil, err
+	}
+	repo.attachClient(r.c)
+	return repo, nil
 }
 
 func (r *Repository) buildContentsURL(ro *RepositoryFilesOptions) (string, error) {
@@ -601,7 +629,12 @@ func (r *Repository) Update(ro *RepositoryOptions) (*Repository, error) {
 	if err != nil {
 		return nil, err
 	}
-	return decodeRepository(response)
+	repo, err := decodeRepository(response)
+	if err != nil {
+		return nil, err
+	}
+	repo.attachClient(r.c)
+	return repo, nil
 }
 
 func (r *Repository) Delete(ro *RepositoryOptions) (interface{}, error) {

--- a/repository_test.go
+++ b/repository_test.go
@@ -1596,6 +1596,97 @@ func TestBuildRepositoryUserPermissionBody(t *testing.T) {
 	assert.Equal(t, "admin", body["permission"])
 }
 
+// --- Regression: returned *Repository must carry a usable client ---
+// https://github.com/ktrysmt/go-bitbucket/issues/347
+
+func TestRepositoryGet_ReturnedRepoHasClient(t *testing.T) {
+	t.Parallel()
+	client, server := setupMockServer(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/2.0/repositories/owner/my-repo":
+			respondJSON(w, http.StatusOK, map[string]interface{}{
+				"slug": "my-repo", "full_name": "owner/my-repo", "name": "my-repo",
+			})
+		case "/2.0/repositories/owner/my-repo/src/main/README.md":
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("hello"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	defer server.Close()
+
+	repo, err := client.Repositories.Repository.Get(&RepositoryOptions{Owner: "owner", RepoSlug: "my-repo"})
+	require.NoError(t, err)
+	require.NotNil(t, repo)
+
+	content, err := repo.GetFileContent(&RepositoryFilesOptions{
+		Owner: "owner", RepoSlug: "my-repo", Ref: "main", Path: "README.md",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(content))
+}
+
+func TestRepositoryCreate_ReturnedRepoHasClient(t *testing.T) {
+	t.Parallel()
+	client, server := setupMockServer(func(w http.ResponseWriter, r *http.Request) {
+		respondJSON(w, http.StatusOK, map[string]interface{}{"slug": "my-repo"})
+	})
+	defer server.Close()
+
+	repo, err := client.Repositories.Repository.Create(&RepositoryOptions{Owner: "owner", RepoSlug: "my-repo"})
+	require.NoError(t, err)
+	require.NotNil(t, repo)
+	assert.Same(t, client, repo.c)
+}
+
+func TestRepositoryFork_ReturnedRepoHasClient(t *testing.T) {
+	t.Parallel()
+	client, server := setupMockServer(func(w http.ResponseWriter, r *http.Request) {
+		respondJSON(w, http.StatusOK, map[string]interface{}{"slug": "forked"})
+	})
+	defer server.Close()
+
+	repo, err := client.Repositories.Repository.Fork(&RepositoryForkOptions{
+		FromOwner: "orig", FromSlug: "orig-repo", Owner: "new", Name: "forked",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, repo)
+	assert.Same(t, client, repo.c)
+}
+
+func TestRepositoryUpdate_ReturnedRepoHasClient(t *testing.T) {
+	t.Parallel()
+	client, server := setupMockServer(func(w http.ResponseWriter, r *http.Request) {
+		respondJSON(w, http.StatusOK, map[string]interface{}{"slug": "my-repo"})
+	})
+	defer server.Close()
+
+	repo, err := client.Repositories.Repository.Update(&RepositoryOptions{Owner: "owner", RepoSlug: "my-repo"})
+	require.NoError(t, err)
+	require.NotNil(t, repo)
+	assert.Same(t, client, repo.c)
+}
+
+func TestRepositoriesList_ItemsHaveClient(t *testing.T) {
+	t.Parallel()
+	client, server := setupMockServer(func(w http.ResponseWriter, r *http.Request) {
+		respondJSON(w, http.StatusOK, paginatedResponse([]interface{}{
+			map[string]interface{}{"slug": "repo1", "full_name": "owner/repo1"},
+			map[string]interface{}{"slug": "repo2", "full_name": "owner/repo2"},
+		}))
+	})
+	defer server.Close()
+
+	res, err := client.Repositories.ListForAccount(&RepositoriesOptions{Owner: "owner"})
+	require.NoError(t, err)
+	require.Len(t, res.Items, 2)
+	for i := range res.Items {
+		assert.Same(t, client, res.Items[i].c, "item %d should have client wired", i)
+	}
+}
+
 // --- Decode Functions ---
 
 func TestDecodeRepository_Success(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fixes #347: `*Repository` values returned from `Repositories.Repository.Get/Create/Fork/Update` and from `Repositories.ListForAccount/ListProject/ListPublic` had a nil internal `*Client`, so calling any method on them (e.g. `repo.GetFileContent(...)`) panicked with a nil-pointer dereference.
- After decoding the API response, the parent client is now wired onto the returned `*Repository` (and its `Parent`, recursively) via a small `attachClient` helper. Items in `RepositoriesRes.Items` get the same treatment.

## Reproduction (before fix)
```go
bb, _ := bitbucket.NewBasicAuth(...)
repo, _ := bb.Repositories.Repository.Get(&bitbucket.RepositoryOptions{...})
// panics: repo.c is nil
_, _ = repo.GetFileContent(&bitbucket.RepositoryFilesOptions{...})
```

## Test plan
- [x] `go build ./...`
- [x] New regression tests in `repository_test.go` cover Get/Create/Fork/Update return values and `Repositories.ListForAccount` items, asserting the client field is wired up. The Get test additionally exercises `repo.GetFileContent` end-to-end against a mock server to confirm no panic.
- [x] `go test ./.` — all repository/repositories tests pass. (Pre-existing failures in `TestDecodeWorkspaceList_Success` and the integration suite under `tests/` are unrelated to this change and reproduce on master.)