### PR TITLE
feat: add NewAPITokenAuth and document Isolated Cloud Instance auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,67 @@ And the response type is json format defined Bitbucket API.
 go get github.com/ktrysmt/go-bitbucket
 ```
 
+## Authentication
+
+Bitbucket Cloud accepts several credential types. Pick the constructor that
+matches your credential.
+
+### API token (recommended)
+
+Atlassian has deprecated app passwords; use an Atlassian API token instead.
+Pass your Atlassian account email as the username and the API token as the
+password.
+
+```go
+c := bitbucket.NewAPITokenAuth("you@example.com", "your-api-token")
+```
+
+`NewAPITokenAuth` is a thin alias over `NewBasicAuth` that documents the
+intended usage. See the
+[Atlassian API token guide](https://support.atlassian.com/bitbucket-cloud/docs/using-api-tokens/).
+
+### App password (legacy)
+
+```go
+c := bitbucket.NewBasicAuth("username", "app-password")
+```
+
+### OAuth bearer token
+
+```go
+c, err := bitbucket.NewOAuthbearerToken("access-token")
+```
+
+### Custom API base URL (Isolated Cloud Instances, self-hosted, proxies)
+
+When the API is reachable under a customer-specific hostname, pass the base
+URL alongside the credential:
+
+```go
+c, err := bitbucket.NewAPITokenAuthWithBaseUrlStr(
+    "you@example.com",
+    "your-api-token",
+    "https://api.your-isolated-instance.example.com/2.0",
+)
+```
+
+If the endpoint uses a private CA, supply the PEM bundle:
+
+```go
+caBundle, _ := os.ReadFile("/etc/ssl/private-ca.pem")
+c, err := bitbucket.NewAPITokenAuthWithBaseUrlStrCaCert(
+    "you@example.com",
+    "your-api-token",
+    "https://api.your-isolated-instance.example.com/2.0",
+    caBundle,
+)
+```
+
+The same `*WithBaseUrlStr` and `*WithBaseUrlStrCaCert` variants exist for
+`NewBasicAuth` and `NewOAuthbearerToken`. Alternatively, set
+`BITBUCKET_API_BASE_URL` in the environment to override the default for any
+constructor that does not take a URL argument.
+
 ## Usage
 
 ### create a pullrequest
@@ -32,7 +93,7 @@ import (
 )
 
 func main() {
-        c := bitbucket.NewBasicAuth("username", "password")
+        c := bitbucket.NewAPITokenAuth("you@example.com", "your-api-token")
 
         opt := &bitbucket.PullRequestsOptions{
                 Owner:             "your-team",
@@ -64,7 +125,7 @@ import (
 )
 
 func main() {
-        c := bitbucket.NewBasicAuth("username", "password")
+        c := bitbucket.NewAPITokenAuth("you@example.com", "your-api-token")
 
         opt := &bitbucket.RepositoryOptions{
                 Owner:    "project_name",

--- a/client.go
+++ b/client.go
@@ -230,6 +230,11 @@ func NewOAuthbearerTokenWithBaseUrlStrCaCert(t, u string, c []byte) (*Client, er
 	return injectClient(a)
 }
 
+// NewBasicAuth returns a Client authenticated via HTTP Basic auth.
+//
+// Atlassian has deprecated Bitbucket Cloud app passwords in favor of
+// Atlassian API tokens. For new integrations, prefer NewAPITokenAuth, which
+// delegates to NewBasicAuth but documents the email + API token usage.
 func NewBasicAuth(u, p string) (*Client, error) {
 	a := &auth{user: u, password: p}
 	return injectClient(a)
@@ -256,6 +261,36 @@ func NewBasicAuthWithBaseUrlStrCaCert(u, p, urlStr string, c []byte) (*Client, e
 	}
 	a := &auth{user: u, password: p, apiBaseUrl: apiBaseURL, caCerts: c}
 	return injectClient(a)
+}
+
+// NewAPITokenAuth returns a Client authenticated with an Atlassian API token.
+// Pass the Atlassian account email as the first argument and the API token as
+// the second. Bitbucket Cloud accepts API tokens via HTTP Basic auth, so this
+// is a thin alias over NewBasicAuth that makes the intent explicit.
+//
+// See https://support.atlassian.com/bitbucket-cloud/docs/using-api-tokens/
+func NewAPITokenAuth(email, token string) (*Client, error) {
+	return NewBasicAuth(email, token)
+}
+
+// NewAPITokenAuthWithBaseUrlStr is like NewAPITokenAuth but targets a custom
+// API base URL (e.g. an Isolated Cloud Instance with a customer-specific
+// hostname). Equivalent to BITBUCKET_API_BASE_URL but configured per client.
+func NewAPITokenAuthWithBaseUrlStr(email, token, urlStr string) (*Client, error) {
+	return NewBasicAuthWithBaseUrlStr(email, token, urlStr)
+}
+
+// NewAPITokenAuthWithCaCert is like NewAPITokenAuth but trusts the supplied
+// PEM-encoded CA certificates in addition to the system roots.
+func NewAPITokenAuthWithCaCert(email, token string, caCerts []byte) (*Client, error) {
+	return NewBasicAuthWithCaCert(email, token, caCerts)
+}
+
+// NewAPITokenAuthWithBaseUrlStrCaCert combines a custom API base URL with
+// extra trusted CA certificates. Suited for Isolated Cloud Instances behind
+// an internal certificate authority.
+func NewAPITokenAuthWithBaseUrlStrCaCert(email, token, urlStr string, caCerts []byte) (*Client, error) {
+	return NewBasicAuthWithBaseUrlStrCaCert(email, token, urlStr, caCerts)
 }
 
 func injectClient(a *auth) (*Client, error) {

--- a/client_test.go
+++ b/client_test.go
@@ -526,6 +526,65 @@ func TestNewBasicAuthWithBaseUrlStr_InvalidURL(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestNewAPITokenAuth(t *testing.T) {
+	t.Parallel()
+	client, err := NewAPITokenAuth("user@example.com", "api-token")
+
+	require.NoError(t, err)
+	assert.Equal(t, "user@example.com", client.Auth.user)
+	assert.Equal(t, "api-token", client.Auth.password)
+	assert.NotNil(t, client.HttpClient)
+	assert.NotNil(t, client.Repositories)
+}
+
+func TestNewAPITokenAuthWithBaseUrlStr(t *testing.T) {
+	t.Parallel()
+	client, err := NewAPITokenAuthWithBaseUrlStr("user@example.com", "api-token", "https://custom.example.com/2.0")
+
+	require.NoError(t, err)
+	assert.Equal(t, "user@example.com", client.Auth.user)
+	assert.Equal(t, "api-token", client.Auth.password)
+	assert.Contains(t, client.GetApiBaseURL(), "custom.example.com")
+}
+
+func TestNewAPITokenAuthWithBaseUrlStr_InvalidURL(t *testing.T) {
+	t.Parallel()
+	_, err := NewAPITokenAuthWithBaseUrlStr("user@example.com", "api-token", "://invalid")
+
+	assert.Error(t, err)
+}
+
+func TestNewAPITokenAuthWithCaCert(t *testing.T) {
+	t.Parallel()
+	cert := generateSelfSignedCert(t)
+	client, err := NewAPITokenAuthWithCaCert("user@example.com", "api-token", cert)
+
+	require.NoError(t, err)
+	assert.Equal(t, "user@example.com", client.Auth.user)
+	require.NotNil(t, client.HttpClient)
+	transport, ok := client.HttpClient.Transport.(*http.Transport)
+	require.True(t, ok, "transport should be *http.Transport")
+	require.NotNil(t, transport.TLSClientConfig)
+	assert.NotNil(t, transport.TLSClientConfig.RootCAs)
+}
+
+func TestNewAPITokenAuthWithBaseUrlStrCaCert(t *testing.T) {
+	t.Parallel()
+	cert := generateSelfSignedCert(t)
+	client, err := NewAPITokenAuthWithBaseUrlStrCaCert("user@example.com", "api-token", "https://custom.example.com/2.0", cert)
+
+	require.NoError(t, err)
+	assert.Contains(t, client.GetApiBaseURL(), "custom.example.com")
+}
+
+func TestNewAPITokenAuthWithBaseUrlStrCaCert_InvalidURL(t *testing.T) {
+	t.Parallel()
+	cert := generateSelfSignedCert(t)
+	_, err := NewAPITokenAuthWithBaseUrlStrCaCert("user@example.com", "api-token", "://invalid", cert)
+
+	assert.Error(t, err)
+}
+
 func TestNewOAuthbearerToken(t *testing.T) {
 	t.Parallel()
 	client, err := NewOAuthbearerToken("my-token")

--- a/workspaces_test.go
+++ b/workspaces_test.go
@@ -20,18 +20,22 @@ func TestWorkspaceList_Success(t *testing.T) {
 			"size":    float64(2),
 			"values": []interface{}{
 				map[string]interface{}{
-					"slug":       "workspace1",
-					"name":       "Workspace One",
-					"uuid":       "{ws-1}",
-					"type":       "workspace",
-					"is_private": false,
+					"workspace": map[string]interface{}{
+						"slug":       "workspace1",
+						"name":       "Workspace One",
+						"uuid":       "{ws-1}",
+						"type":       "workspace",
+						"is_private": false,
+					},
 				},
 				map[string]interface{}{
-					"slug":       "workspace2",
-					"name":       "Workspace Two",
-					"uuid":       "{ws-2}",
-					"type":       "workspace",
-					"is_private": true,
+					"workspace": map[string]interface{}{
+						"slug":       "workspace2",
+						"name":       "Workspace Two",
+						"uuid":       "{ws-2}",
+						"type":       "workspace",
+						"is_private": true,
+					},
 				},
 			},
 		})
@@ -41,7 +45,7 @@ func TestWorkspaceList_Success(t *testing.T) {
 	result, err := client.Workspaces.List()
 
 	require.NoError(t, err)
-	assert.Equal(t, "/2.0/workspaces", receivedPath)
+	assert.Equal(t, "/2.0/user/workspaces", receivedPath)
 	assert.Len(t, result.Workspaces, 2)
 	assert.Equal(t, 1, result.Page)
 	assert.Equal(t, 10, result.Pagelen)
@@ -273,9 +277,11 @@ func TestDecodeWorkspaceList_Success(t *testing.T) {
 		"size":    float64(1),
 		"values": []interface{}{
 			map[string]interface{}{
-				"slug": "ws1",
-				"name": "Workspace 1",
-				"type": "workspace",
+				"workspace": map[string]interface{}{
+					"slug": "ws1",
+					"name": "Workspace 1",
+					"type": "workspace",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

- Adds `NewAPITokenAuth` and the `WithBaseUrlStr` / `WithCaCert` variants as semantic aliases over the existing `NewBasicAuth*` family. Atlassian API tokens already work over Basic auth, but the existing entry points do not signal that, leaving users unsure how to migrate from app passwords.
- Restructures `README.md` with an `Authentication` section covering API tokens (recommended), app passwords (legacy), OAuth bearer tokens, custom API base URLs (Isolated Cloud Instances), private CA bundles, and the `BITBUCKET_API_BASE_URL` env var. Existing usage snippets switch from `NewBasicAuth("username", "password")` to `NewAPITokenAuth("you@example.com", "your-api-token")`.
- Documents the migration on `NewBasicAuth` itself via a Go doc comment.
- Includes a small unrelated fix: `TestWorkspaceList_Success` and `TestDecodeWorkspaceList_Success` were broken on master by #358 (path moved to `/2.0/user/workspaces`, response now wraps each entry under a `workspace` key). Updated the mock payloads and expected path so the unit suite is green again.

Closes #308
Closes #346

## Background

- App passwords stop working on 2026-06-09 (Atlassian announcement: https://www.atlassian.com/blog/bitbucket/bitbucket-cloud-transitions-to-api-tokens-enhancing-security-with-app-password-deprecation). API tokens are the supported successor and are passed via HTTP Basic auth as `email + token` (https://support.atlassian.com/bitbucket-cloud/docs/using-api-tokens/).
- Isolated Cloud Instances expose the API under a customer-specific hostname; users currently need to know that `*WithBaseUrlStr` constructors exist or to set `BITBUCKET_API_BASE_URL`. The README change makes both discoverable; the new `NewAPITokenAuthWithBaseUrlStr*` constructors cover the most common combination.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...` (only the pre-existing `bitbucket.go:274` json tag warning, unrelated to this PR)
- [x] `go test -count=1 . ./mock_tests/...` — all unit + mock tests pass, including the six new `TestNewAPITokenAuth*` cases
- [x] Swagger contract layer (`make test/swagger` against Stoplight Prism + `api.bitbucket.org/swagger.json`) — ran the suite and compared against master. The failures observed are pre-existing (e.g. `tests/branchrestrictions_test.go:30-32` panics on a nil response after a 422; same crash reproduces on `master`). This PR adds no new code paths exercised by `tests/`, so there is no regression in that layer. Cleanup of those panics and a CI job for the swagger layer are tracked in #361.
- [ ] Live e2e suite (`make test/e2e`) — not run here; requires Bitbucket credentials.

## Follow-ups (separate)

Tracked in #361:

- Migrate the `BITBUCKET_TEST_USERNAME` / `BITBUCKET_TEST_PASSWORD` e2e fixtures to API tokens before 2026-06-09.
- Wire `make test/swagger` into CI using the OpenAPI v3 spec at `https://developer.atlassian.com/cloud/bitbucket/swagger.v3.json`, after first hardening `tests/` against nil-response panics so the swagger layer can fail meaningfully instead of crashing.