### PR TITLE
fix: decode bugs in workspaces.go and duplicate uuid json tag

### DIFF
--- a/bitbucket.go
+++ b/bitbucket.go
@@ -269,9 +269,9 @@ type RepositoryBranchCreationOptions struct {
 type RepositoryBranchDeleteOptions struct {
 	Owner    string `json:"owner"`
 	RepoSlug string `json:"repo_slug"`
-	RepoUUID string `json:"uuid"`
+	RepoUUID string `json:"repo_uuid"`
 	RefName  string `json:"name"`
-	RefUUID  string `json:"uuid"`
+	RefUUID  string `json:"ref_uuid"`
 }
 
 type RepositoryBranchTarget struct {

--- a/workspaces.go
+++ b/workspaces.go
@@ -221,7 +221,7 @@ func decodeProjects(projectResponse interface{}) (*ProjectsRes, error) {
 	if !ok {
 		pagelen = 0
 	}
-	max_depth, ok := projectsResponseMap["max_width"].(float64)
+	max_depth, ok := projectsResponseMap["max_depth"].(float64)
 	if !ok {
 		max_depth = 0
 	}
@@ -258,23 +258,23 @@ func decodeMembers(membersResponse interface{}) (*WorkspaceMembers, error) {
 		members = append(members, *member)
 	}
 
-	page, ok := responseMap["page"].(int)
+	page, ok := responseMap["page"].(float64)
 	if !ok {
 		page = 0
 	}
-	pagelen, ok := responseMap["pagelen"].(int)
+	pagelen, ok := responseMap["pagelen"].(float64)
 	if !ok {
 		pagelen = 0
 	}
-	size, ok := responseMap["size"].(int)
+	size, ok := responseMap["size"].(float64)
 	if !ok {
 		size = 0
 	}
 
 	workspaceMembers := WorkspaceMembers{
-		Page:    page,
-		Pagelen: pagelen,
-		Size:    size,
+		Page:    int(page),
+		Pagelen: int(pagelen),
+		Size:    int(size),
 		Members: members,
 	}
 	return &workspaceMembers, nil

--- a/workspaces_test.go
+++ b/workspaces_test.go
@@ -355,10 +355,7 @@ func TestDecodeProjects_Success(t *testing.T) {
 	assert.Equal(t, "{proj-uuid-1}", result.Items[0].Uuid)
 }
 
-// TestDecodeProjects_MaxDepthBug documents a known bug in decodeProjects:
-// line 214 of workspaces.go reads "max_width" instead of "max_depth",
-// so MaxDepth is always 0 even when "max_depth" is provided in the response.
-func TestDecodeProjects_MaxDepthBug(t *testing.T) {
+func TestDecodeProjects_MaxDepth(t *testing.T) {
 	t.Parallel()
 	response := map[string]interface{}{
 		"page":      float64(1),
@@ -371,8 +368,7 @@ func TestDecodeProjects_MaxDepthBug(t *testing.T) {
 	result, err := decodeProjects(response)
 
 	require.NoError(t, err)
-	// BUG: MaxDepth should be 5 but the code reads "max_width" instead of "max_depth"
-	assert.Equal(t, int32(0), result.MaxDepth, "MaxDepth is always 0 because code reads 'max_width' instead of 'max_depth'")
+	assert.Equal(t, int32(5), result.MaxDepth)
 }
 
 func TestDecodeProjects_InvalidFormat(t *testing.T) {
@@ -383,10 +379,7 @@ func TestDecodeProjects_InvalidFormat(t *testing.T) {
 	assert.Contains(t, err.Error(), "Not a valid format")
 }
 
-// TestDecodeMembers_PaginationFieldsAreZero documents that decodeMembers
-// expects page/pagelen/size as int, but JSON unmarshal produces float64,
-// so pagination fields are always 0 in practice.
-func TestDecodeMembers_PaginationFieldsAreZero(t *testing.T) {
+func TestDecodeMembers_PaginationFields(t *testing.T) {
 	t.Parallel()
 	response := map[string]interface{}{
 		"page":    float64(3),
@@ -411,9 +404,7 @@ func TestDecodeMembers_PaginationFieldsAreZero(t *testing.T) {
 	assert.Equal(t, "testuser", result.Members[0].Username)
 	assert.Equal(t, "Test User", result.Members[0].DisplayName)
 	assert.Equal(t, "{user-uuid}", result.Members[0].Uuid)
-	// BUG: decodeMembers uses type assertion .(int) but JSON produces float64,
-	// so the assertion always fails and pagination fields default to 0.
-	assert.Equal(t, 0, result.Page, "Page is 0 because .(int) type assertion fails on float64")
-	assert.Equal(t, 0, result.Pagelen, "Pagelen is 0 because .(int) type assertion fails on float64")
-	assert.Equal(t, 0, result.Size, "Size is 0 because .(int) type assertion fails on float64")
+	assert.Equal(t, 3, result.Page)
+	assert.Equal(t, 25, result.Pagelen)
+	assert.Equal(t, 1, result.Size)
 }


### PR DESCRIPTION
## Summary
- `decodeProjects` read `max_width` instead of `max_depth`, so `ProjectsRes.MaxDepth` was always 0 even when the API responded with `max_depth`.
- `decodeMembers` used `.(int)` type assertions on values that JSON unmarshal produces as `float64`, so `WorkspaceMembers.Page/Pagelen/Size` were always 0 in practice.
- `RepositoryBranchDeleteOptions` had two fields tagged `json:"uuid"`, flagged by `go vet`. Renamed to `repo_uuid` / `ref_uuid` (the struct is used to build URL params, not request bodies, so the rename has no API impact).
- Flipped the `BUG`-pinning tests in `workspaces_test.go` to assert the correct values.

Closes #363

## Test plan
- [x] `go vet ./...` clean
- [x] `make test/unit-short`
- [x] `make test/mock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)