### PR TITLE
feat: support custom OAuth endpoint for Isolated Cloud Instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,10 @@
 
 > Bitbucket-API library for golang.
 
-Support Bitbucket API v2.0.
+Supports Bitbucket Cloud REST API v2.0. Responses follow the JSON shape
+documented by the official API.
 
-And the response type is json format defined Bitbucket API.
-
-- Bitbucket API v2.0 <https://developer.atlassian.com/bitbucket/api/2/reference/resource/>
+- Bitbucket Cloud REST API v2.0 <https://developer.atlassian.com/cloud/bitbucket/rest/intro/>
 - Swagger for API v2.0 <https://api.bitbucket.org/swagger.json>
 
 ## Install
@@ -49,10 +48,43 @@ c := bitbucket.NewBasicAuth("username", "app-password")
 c, err := bitbucket.NewOAuthbearerToken("access-token")
 ```
 
+### OAuth flow (client credentials, authorization code, refresh token)
+
+If you obtain tokens through the OAuth handshake yourself, use one of:
+
+```go
+c, err := bitbucket.NewOAuthClientCredentials("client-id", "client-secret")
+c, accessToken, err := bitbucket.NewOAuthWithCode("client-id", "client-secret", "auth-code")
+c, accessToken, err := bitbucket.NewOAuthWithRefreshToken("client-id", "client-secret", "refresh-token")
+```
+
+For Isolated Cloud Instances whose OAuth token endpoint lives under a
+customer-specific hostname, the matching `*WithEndpoint` variants override the
+default `bitbucket.Endpoint`:
+
+```go
+import "golang.org/x/oauth2"
+
+ep := oauth2.Endpoint{
+    AuthURL:  "https://auth.your-isolated-instance.example.com/site/oauth2/authorize",
+    TokenURL: "https://auth.your-isolated-instance.example.com/site/oauth2/access_token",
+}
+
+c, err := bitbucket.NewOAuthClientCredentialsWithEndpoint(
+    "client-id", "client-secret", ep.TokenURL,
+)
+c, accessToken, err := bitbucket.NewOAuthWithCodeWithEndpoint(
+    "client-id", "client-secret", "auth-code", ep,
+)
+c, accessToken, err := bitbucket.NewOAuthWithRefreshTokenWithEndpoint(
+    "client-id", "client-secret", "refresh-token", ep,
+)
+```
+
 ### Custom API base URL (Isolated Cloud Instances, self-hosted, proxies)
 
-When the API is reachable under a customer-specific hostname, pass the base
-URL alongside the credential:
+When the REST API is reachable under a customer-specific hostname, pass the
+base URL alongside the credential:
 
 ```go
 c, err := bitbucket.NewAPITokenAuthWithBaseUrlStr(
@@ -75,7 +107,9 @@ c, err := bitbucket.NewAPITokenAuthWithBaseUrlStrCaCert(
 ```
 
 The same `*WithBaseUrlStr` and `*WithBaseUrlStrCaCert` variants exist for
-`NewBasicAuth` and `NewOAuthbearerToken`. Alternatively, set
+`NewBasicAuth` and `NewOAuthbearerToken`. For OAuth-handshake constructors,
+combine the `*WithEndpoint` variant above with `client.SetApiBaseURL` to
+redirect REST traffic to the same host. Alternatively, set
 `BITBUCKET_API_BASE_URL` in the environment to override the default for any
 constructor that does not take a URL argument.
 
@@ -203,7 +237,7 @@ Individually;
 go test ./mock_tests/repository_mock_test.go
 ```
 
-For documented workflow of the go:qmock test structure in ```/mock_tests/repository_mock_test.go``` refer to;
+For documented workflow of the gomock test structure in ```/mock_tests/repository_mock_test.go``` refer to;
 - TestMockRepositoryPipelineVariables_List_Success
 - TestMockRepositoryPipelineVariables_List_Error
 

--- a/client.go
+++ b/client.go
@@ -99,12 +99,19 @@ type Response struct {
 
 // Uses the Client Credentials Grant oauth2 flow to authenticate to Bitbucket
 func NewOAuthClientCredentials(i, s string) (*Client, error) {
+	return NewOAuthClientCredentialsWithEndpoint(i, s, bitbucket.Endpoint.TokenURL)
+}
+
+// NewOAuthClientCredentialsWithEndpoint is like NewOAuthClientCredentials but
+// targets a custom OAuth token endpoint (e.g. an Isolated Cloud Instance with
+// a customer-specific hostname).
+func NewOAuthClientCredentialsWithEndpoint(i, s, tokenURL string) (*Client, error) {
 	a := &auth{appID: i, secret: s}
 	ctx := context.Background()
 	conf := &clientcredentials.Config{
 		ClientID:     i,
 		ClientSecret: s,
-		TokenURL:     bitbucket.Endpoint.TokenURL,
+		TokenURL:     tokenURL,
 	}
 
 	tok, err := conf.Token(ctx)
@@ -123,12 +130,21 @@ func NewOAuthClientCredentials(i, s string) (*Client, error) {
 // NewOAuthWithCode after obtaining the authorization code through your own UI/CLI.
 // You can generate the authorization URL using oauth2.Config.AuthCodeURL() directly.
 func NewOAuth(i, s string) (*Client, error) {
+	return NewOAuthWithEndpoint(i, s, bitbucket.Endpoint)
+}
+
+// NewOAuthWithEndpoint is like NewOAuth but targets a custom OAuth endpoint
+// (e.g. an Isolated Cloud Instance with a customer-specific hostname).
+//
+// Deprecated: This function uses stdin/stdout directly, making it unsuitable
+// for non-interactive environments. Prefer NewOAuthWithCodeWithEndpoint.
+func NewOAuthWithEndpoint(i, s string, ep oauth2.Endpoint) (*Client, error) {
 	a := &auth{appID: i, secret: s}
 	ctx := context.Background()
 	conf := &oauth2.Config{
 		ClientID:     i,
 		ClientSecret: s,
-		Endpoint:     bitbucket.Endpoint,
+		Endpoint:     ep,
 	}
 
 	// Redirect user to consent page to ask for permission
@@ -156,12 +172,19 @@ func NewOAuth(i, s string) (*Client, error) {
 // NewOAuthWithCode finishes the OAuth handshake with a given code
 // and returns a *Client
 func NewOAuthWithCode(i, s, c string) (*Client, string, error) {
+	return NewOAuthWithCodeWithEndpoint(i, s, c, bitbucket.Endpoint)
+}
+
+// NewOAuthWithCodeWithEndpoint is like NewOAuthWithCode but targets a custom
+// OAuth endpoint (e.g. an Isolated Cloud Instance with a customer-specific
+// hostname).
+func NewOAuthWithCodeWithEndpoint(i, s, c string, ep oauth2.Endpoint) (*Client, string, error) {
 	a := &auth{appID: i, secret: s}
 	ctx := context.Background()
 	conf := &oauth2.Config{
 		ClientID:     i,
 		ClientSecret: s,
-		Endpoint:     bitbucket.Endpoint,
+		Endpoint:     ep,
 	}
 
 	tok, err := conf.Exchange(ctx, c)
@@ -179,12 +202,19 @@ func NewOAuthWithCode(i, s, c string) (*Client, string, error) {
 // NewOAuthWithRefreshToken obtains a new access token with a given refresh token
 // and returns a *Client
 func NewOAuthWithRefreshToken(i, s, rt string) (*Client, string, error) {
+	return NewOAuthWithRefreshTokenWithEndpoint(i, s, rt, bitbucket.Endpoint)
+}
+
+// NewOAuthWithRefreshTokenWithEndpoint is like NewOAuthWithRefreshToken but
+// targets a custom OAuth endpoint (e.g. an Isolated Cloud Instance with a
+// customer-specific hostname).
+func NewOAuthWithRefreshTokenWithEndpoint(i, s, rt string, ep oauth2.Endpoint) (*Client, string, error) {
 	a := &auth{appID: i, secret: s}
 	ctx := context.Background()
 	conf := &oauth2.Config{
 		ClientID:     i,
 		ClientSecret: s,
-		Endpoint:     bitbucket.Endpoint,
+		Endpoint:     ep,
 	}
 
 	tokenSource := conf.TokenSource(ctx, &oauth2.Token{

--- a/client_test.go
+++ b/client_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 )
 
 func generateSelfSignedCert(t *testing.T) []byte {
@@ -709,4 +710,65 @@ func TestAppendCaCerts_InvalidPEM(t *testing.T) {
 	_, err := appendCaCerts([]byte("not a valid PEM"))
 
 	assert.Error(t, err)
+}
+
+func TestNewOAuthClientCredentialsWithEndpoint(t *testing.T) {
+	t.Parallel()
+	var receivedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"access_token":"custom-cc-token","token_type":"bearer","expires_in":3600}`)
+	}))
+	defer server.Close()
+
+	client, err := NewOAuthClientCredentialsWithEndpoint("id", "secret", server.URL+"/site/oauth2/access_token")
+
+	require.NoError(t, err)
+	assert.Equal(t, "/site/oauth2/access_token", receivedPath)
+	assert.Equal(t, "custom-cc-token", client.Auth.token.AccessToken)
+}
+
+func TestNewOAuthWithCodeWithEndpoint(t *testing.T) {
+	t.Parallel()
+	var receivedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"access_token":"custom-code-token","token_type":"bearer","expires_in":3600}`)
+	}))
+	defer server.Close()
+
+	ep := oauth2.Endpoint{
+		AuthURL:  server.URL + "/site/oauth2/authorize",
+		TokenURL: server.URL + "/site/oauth2/access_token",
+	}
+	client, accessToken, err := NewOAuthWithCodeWithEndpoint("id", "secret", "code", ep)
+
+	require.NoError(t, err)
+	assert.Equal(t, "/site/oauth2/access_token", receivedPath)
+	assert.Equal(t, "custom-code-token", accessToken)
+	assert.Equal(t, "custom-code-token", client.Auth.token.AccessToken)
+}
+
+func TestNewOAuthWithRefreshTokenWithEndpoint(t *testing.T) {
+	t.Parallel()
+	var receivedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"access_token":"custom-refresh-token","token_type":"bearer","expires_in":3600}`)
+	}))
+	defer server.Close()
+
+	ep := oauth2.Endpoint{
+		AuthURL:  server.URL + "/site/oauth2/authorize",
+		TokenURL: server.URL + "/site/oauth2/access_token",
+	}
+	client, accessToken, err := NewOAuthWithRefreshTokenWithEndpoint("id", "secret", "rt", ep)
+
+	require.NoError(t, err)
+	assert.Equal(t, "/site/oauth2/access_token", receivedPath)
+	assert.Equal(t, "custom-refresh-token", accessToken)
+	assert.Equal(t, "custom-refresh-token", client.Auth.token.AccessToken)
 }


### PR DESCRIPTION
## Summary
- Adds `NewOAuthClientCredentialsWithEndpoint`, `NewOAuthWithEndpoint`, `NewOAuthWithCodeWithEndpoint`, and `NewOAuthWithRefreshTokenWithEndpoint`. They override the hardcoded `bitbucket.Endpoint` so the OAuth handshake works against an Isolated Cloud Instance's own hostname.
- The existing four constructors now delegate to the new ones with `bitbucket.Endpoint`, so callers are unchanged.
- README gets an OAuth flow section (constructors that were never documented) plus the new `WithEndpoint` variants. Minor unrelated polish: `go:qmock` typo and the API reference URL.

Closes #362

## Test plan
- [x] `go build ./...`
- [x] `make test/unit-short`
- [x] `make test/mock`
- [x] New `httptest`-based unit tests for each `WithEndpoint` constructor (`client_test.go`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)