### PR TITLE
ci: add minimum GitHub Actions workflow for build, vet, and tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: test
+on:
+  push:
+    branches: [master]
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go vet ./...
+      - run: make test/ci


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/test.yml`. Triggers on push to `master` and on every PR.
- Steps: `go vet ./...` then `make test/ci` (build + `test/unit-short` + `test/mock`).
- Go version is read from `go.mod` via `actions/setup-go@v5`'s `go-version-file`, keeping the workflow in lockstep with the module. Module caching is provided by setup-go.

Closes #364

Live e2e and the OpenAPI/Prism contract job are intentionally out of scope here and tracked separately.

## Test plan
- [x] `go vet ./...` clean locally
- [x] `make test/ci` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)