### PR TITLE
fix: branch-restrictions body schema and tests panic-on-error

### DIFF
--- a/bitbucket.go
+++ b/bitbucket.go
@@ -430,10 +430,15 @@ type BranchRestrictionsOptions struct {
 	Pattern  string            `json:"pattern"`
 	Users    []string          `json:"users"`
 	Kind     string            `json:"kind"`
-	FullSlug string            `json:"full_slug"`
-	Name     string            `json:"name"`
-	Value    interface{}       `json:"value"`
-	ctx      context.Context
+	// BranchMatchKind controls how Pattern is matched against branches.
+	// Allowed values are "glob" (default when empty) and "branching_model".
+	BranchMatchKind string `json:"branch_match_kind"`
+	// BranchType is required when BranchMatchKind is "branching_model".
+	BranchType string      `json:"branch_type"`
+	FullSlug   string      `json:"full_slug"`
+	Name       string      `json:"name"`
+	Value      interface{} `json:"value"`
+	ctx        context.Context
 }
 
 func (b *BranchRestrictionsOptions) WithContext(ctx context.Context) *BranchRestrictionsOptions {

--- a/branchrestrictions.go
+++ b/branchrestrictions.go
@@ -64,17 +64,14 @@ func (b *BranchRestrictions) Delete(bo *BranchRestrictionsOptions) (interface{},
 }
 
 type branchRestrictionsBody struct {
-	Kind    string `json:"kind"`
-	Pattern string `json:"pattern"`
-	Links   struct {
-		Self struct {
-			Href string `json:"href"`
-		} `json:"self"`
-	} `json:"links"`
-	Value  interface{}                   `json:"value"`
-	ID     int                           `json:"id"`
-	Users  []branchRestrictionsBodyUser  `json:"users"`
-	Groups []branchRestrictionsBodyGroup `json:"groups"`
+	Type            string                        `json:"type"`
+	Kind            string                        `json:"kind"`
+	BranchMatchKind string                        `json:"branch_match_kind"`
+	BranchType      string                        `json:"branch_type,omitempty"`
+	Pattern         string                        `json:"pattern"`
+	Value           interface{}                   `json:"value,omitempty"`
+	Users           []branchRestrictionsBodyUser  `json:"users"`
+	Groups          []branchRestrictionsBodyGroup `json:"groups"`
 }
 
 type branchRestrictionsBodyGroup struct {
@@ -120,8 +117,8 @@ type branchRestrictionsBodyUser struct {
 }
 
 func (b *BranchRestrictions) buildBranchRestrictionsBody(bo *BranchRestrictionsOptions) (string, error) {
-	var users []branchRestrictionsBodyUser
-	var groups []branchRestrictionsBodyGroup
+	users := make([]branchRestrictionsBodyUser, 0, len(bo.Users))
+	groups := make([]branchRestrictionsBodyGroup, 0, len(bo.Groups))
 	for _, u := range bo.Users {
 		user := branchRestrictionsBodyUser{
 			Username: u,
@@ -135,12 +132,20 @@ func (b *BranchRestrictions) buildBranchRestrictionsBody(bo *BranchRestrictionsO
 		groups = append(groups, group)
 	}
 
+	branchMatchKind := bo.BranchMatchKind
+	if branchMatchKind == "" {
+		branchMatchKind = "glob"
+	}
+
 	body := branchRestrictionsBody{
-		Kind:    bo.Kind,
-		Pattern: bo.Pattern,
-		Users:   users,
-		Groups:  groups,
-		Value:   bo.Value,
+		Type:            "branchrestriction",
+		Kind:            bo.Kind,
+		BranchMatchKind: branchMatchKind,
+		BranchType:      bo.BranchType,
+		Pattern:         bo.Pattern,
+		Users:           users,
+		Groups:          groups,
+		Value:           bo.Value,
 	}
 
 	data, err := json.Marshal(body)

--- a/branchrestrictions_test.go
+++ b/branchrestrictions_test.go
@@ -302,11 +302,35 @@ func TestBuildBranchRestrictionsBody_Empty(t *testing.T) {
 	err = json.Unmarshal([]byte(data), &body)
 	require.NoError(t, err)
 
+	assert.Equal(t, "branchrestriction", body["type"])
 	assert.Equal(t, "push", body["kind"])
 	assert.Equal(t, "main", body["pattern"])
-	// Users and Groups should be null when not provided
-	assert.Nil(t, body["users"])
-	assert.Nil(t, body["groups"])
+	assert.Equal(t, "glob", body["branch_match_kind"])
+	// users/groups serialize as empty arrays so the swagger schema accepts them.
+	assert.Equal(t, []interface{}{}, body["users"])
+	assert.Equal(t, []interface{}{}, body["groups"])
+}
+
+func TestBuildBranchRestrictionsBody_BranchingModel(t *testing.T) {
+	t.Parallel()
+	br := &BranchRestrictions{}
+	opts := &BranchRestrictionsOptions{
+		Kind:            "require_passing_builds_to_merge",
+		Pattern:         "",
+		BranchMatchKind: "branching_model",
+		BranchType:      "production",
+		Value:           2,
+	}
+
+	data, err := br.buildBranchRestrictionsBody(opts)
+
+	require.NoError(t, err)
+	var body map[string]interface{}
+	err = json.Unmarshal([]byte(data), &body)
+	require.NoError(t, err)
+
+	assert.Equal(t, "branching_model", body["branch_match_kind"])
+	assert.Equal(t, "production", body["branch_type"])
 }
 
 func TestDecodeBranchRestriction_Success(t *testing.T) {

--- a/tests/branchrestrictions_test.go
+++ b/tests/branchrestrictions_test.go
@@ -27,7 +27,7 @@ func TestBranchRestrictionsKindPush(t *testing.T) {
 		}
 		res, err := c.Repositories.BranchRestrictions.Create(opt)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 		if res.Kind != "push" {
 			t.Error("did not match branchrestriction kind")
@@ -43,7 +43,7 @@ func TestBranchRestrictionsKindPush(t *testing.T) {
 		}
 		_, err := c.Repositories.BranchRestrictions.Delete(opt)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 	})
 }
@@ -66,7 +66,7 @@ func TestBranchRestrictionsKindRequirePassingBuilds(t *testing.T) {
 		}
 		res, err := c.Repositories.BranchRestrictions.Create(opt)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 		if res.Kind != "require_passing_builds_to_merge" {
 			t.Error("did not match branchrestriction kind")
@@ -82,7 +82,7 @@ func TestBranchRestrictionsKindRequirePassingBuilds(t *testing.T) {
 		}
 		_, err := c.Repositories.BranchRestrictions.Delete(opt)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 	})
 }
@@ -106,7 +106,7 @@ func TestBranchRestrictionsGets(t *testing.T) {
 				}
 				_, err := c.Repositories.BranchRestrictions.Delete(opt)
 				if err != nil {
-					t.Error(err)
+					t.Fatal(err)
 				}
 			}
 		}()
@@ -120,7 +120,7 @@ func TestBranchRestrictionsGets(t *testing.T) {
 			}
 			res, err := c.Repositories.BranchRestrictions.Create(opt)
 			if err != nil {
-				t.Error(err)
+				t.Fatal(err)
 				return
 			}
 
@@ -136,7 +136,7 @@ func TestBranchRestrictionsGets(t *testing.T) {
 
 		res, err := c.Repositories.BranchRestrictions.Gets(opt)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 			return
 		}
 

--- a/tests/deploykeys_test.go
+++ b/tests/deploykeys_test.go
@@ -49,7 +49,7 @@ func TestDeployKey(t *testing.T) {
 
 		deployKey, err := c.Repositories.DeployKeys.Create(opt)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 
 		if deployKey == nil {
@@ -74,7 +74,7 @@ func TestDeployKey(t *testing.T) {
 		}
 		deployKey, err := c.Repositories.DeployKeys.Get(opt)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 
 		if deployKey == nil {
@@ -100,7 +100,7 @@ func TestDeployKey(t *testing.T) {
 		}
 		_, err := c.Repositories.DeployKeys.Delete(opt)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 	})
 }
@@ -145,7 +145,7 @@ func TestDeployKeyWithComment(t *testing.T) {
 
 		deployKey, err := c.Repositories.DeployKeys.Create(opt)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 
 		if deployKey == nil {
@@ -173,7 +173,7 @@ func TestDeployKeyWithComment(t *testing.T) {
 		}
 		deployKey, err := c.Repositories.DeployKeys.Get(opt)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 
 		if deployKey == nil {
@@ -202,7 +202,7 @@ func TestDeployKeyWithComment(t *testing.T) {
 		}
 		_, err := c.Repositories.DeployKeys.Delete(opt)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 	})
 }
@@ -246,7 +246,7 @@ func TestListDeployKeys(t *testing.T) {
 
 		deployKey, err := c.Repositories.DeployKeys.Create(opt)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 
 		if deployKey == nil {
@@ -275,7 +275,7 @@ func TestListDeployKeys(t *testing.T) {
 
 		deployKey, err := c.Repositories.DeployKeys.Create(opt)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 
 		if deployKey == nil {
@@ -300,7 +300,7 @@ func TestListDeployKeys(t *testing.T) {
 		}
 		deployKeys, err := c.Repositories.DeployKeys.List(opt)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 		found := false
 		for _, r := range deployKeys.Items {
@@ -323,7 +323,7 @@ func TestListDeployKeys(t *testing.T) {
 		}
 		_, err := c.Repositories.DeployKeys.Delete(opt)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 	})
 	t.Run("delete", func(t *testing.T) {
@@ -334,7 +334,7 @@ func TestListDeployKeys(t *testing.T) {
 		}
 		_, err := c.Repositories.DeployKeys.Delete(opt)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 	})
 }

--- a/tests/diff_test.go
+++ b/tests/diff_test.go
@@ -37,7 +37,7 @@ func TestDiff(t *testing.T) {
 	}
 	res, err := c.Repositories.Diff.GetDiff(opt)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	pp.Println(res)
@@ -76,7 +76,7 @@ func TestGetDiffStat(t *testing.T) {
 	}
 	res, err := c.Repositories.Diff.GetDiffStat(opt)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	pp.Println(res)
@@ -123,7 +123,7 @@ func TestGetDiffStatWithFields(t *testing.T) {
 
 	res, err := c.Repositories.Diff.GetDiffStat(opt)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	pp.Println(res)

--- a/tests/environment_test.go
+++ b/tests/environment_test.go
@@ -40,7 +40,7 @@ func TestListEnvironments(t *testing.T) {
 
 	res, err := c.Repositories.Repository.ListEnvironments(opt)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if res == nil {
@@ -82,7 +82,7 @@ func TestEndToEndEnvironments(t *testing.T) {
 
 	environment, err := c.Repositories.Repository.AddEnvironment(opt)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if environment.Uuid == "" {
@@ -94,7 +94,7 @@ func TestEndToEndEnvironments(t *testing.T) {
 
 	foundEnvironment, err := c.Repositories.Repository.GetEnvironment(opt)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if foundEnvironment.Name != "foo" {
@@ -110,6 +110,6 @@ func TestEndToEndEnvironments(t *testing.T) {
 	// On success the delete API doesn't return any content (HTTP status 204)
 	_, err = c.Repositories.Repository.DeleteEnvironment(deleteOpt)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 }

--- a/tests/list_test.go
+++ b/tests/list_test.go
@@ -26,7 +26,7 @@ func TestList(t *testing.T) {
 	repos, err := c.Repositories.ListForAccount(opt)
 
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	for _, repo := range repos.Items {
@@ -38,7 +38,7 @@ func TestList(t *testing.T) {
 		res, err := c.Repositories.Repository.ListTags(tagOpt)
 
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 
 		if len(res.Tags) != 0 {

--- a/tests/project_test.go
+++ b/tests/project_test.go
@@ -48,7 +48,7 @@ func TestProjectCreate_isPrivateTrue(t *testing.T) {
 	}
 	project, err := c.Workspaces.CreateProject(opt)
 	if err != nil {
-		t.Error("The project could not be created.")
+		t.Fatal("The project could not be created.")
 	}
 
 	if project.Name != projectName {
@@ -64,7 +64,7 @@ func TestProjectCreate_isPrivateTrue(t *testing.T) {
 	// Delete the project, so we can keep a clean test environment
 	_, err = c.Workspaces.DeleteProject(opt)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 }
 
@@ -81,7 +81,7 @@ func TestProjectCreate_isPrivateFalse(t *testing.T) {
 	}
 	project, err := c.Workspaces.CreateProject(opt)
 	if err != nil {
-		t.Error("The project could not be created.")
+		t.Fatal("The project could not be created.")
 	}
 
 	if project.Name != projectName {
@@ -97,6 +97,6 @@ func TestProjectCreate_isPrivateFalse(t *testing.T) {
 	// Delete the project, so we can keep a clean test environment
 	_, err = c.Workspaces.DeleteProject(opt)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 }

--- a/tests/repositories_test.go
+++ b/tests/repositories_test.go
@@ -35,7 +35,7 @@ func TestListForAccount(t *testing.T) {
 		Owner: owner,
 	})
 	if err != nil {
-		t.Error("Unable to fetch repositories")
+		t.Fatal("Unable to fetch repositories")
 	}
 
 	found := false
@@ -79,7 +79,7 @@ func TestListForAccountWithKeyword(t *testing.T) {
 			Keyword: &repo,
 		})
 		if err != nil {
-			t.Error("Unable to fetch repositories")
+			t.Fatal("Unable to fetch repositories")
 		}
 
 		found := false
@@ -100,7 +100,7 @@ func TestListForAccountWithKeyword(t *testing.T) {
 			Role:    "member",
 		})
 		if err != nil {
-			t.Error("Unable to fetch repositories")
+			t.Fatal("Unable to fetch repositories")
 		}
 
 		found := false
@@ -146,7 +146,7 @@ func TestListForTeam(t *testing.T) {
 		Owner: owner,
 	})
 	if err != nil {
-		t.Error("Unable to fetch repositories")
+		t.Fatal("Unable to fetch repositories")
 	}
 
 	found := false

--- a/tests/repository_access_token_test.go
+++ b/tests/repository_access_token_test.go
@@ -16,7 +16,7 @@ func TestAddGetandDeletePipelineVariableAccess(t *testing.T) {
 
 	client, err := SetupBearerToken(t)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 		return
 	}
 
@@ -35,14 +35,14 @@ func TestAddGetandDeletePipelineVariableAccessWithTokenBaseUrlCaCert(t *testing.
 
 	client0, err := SetupBearerTokenWithBaseUrlStr(t, "")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 		assert.Nilf(t, err, "expected no error returned, but got %v", err)
 	}
 
 	expectedBaseUrlStr := "https://api.bitbucket.org/2.0"
 	client1, err := SetupBearerTokenWithBaseUrlStrCaCert(t, expectedBaseUrlStr, nil)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 		assert.Nilf(t, err, "expected no error returned, but got %v", err)
 	}
 	assert.Equal(t, client0.GetApiBaseURL(), expectedBaseUrlStr)
@@ -62,7 +62,7 @@ func TestAddGetandDeletePipelineVariableAccessWithTokenBaseUrlCaCert(t *testing.
 func testApiCalls(t *testing.T, c *bitbucket.Client, v *bitbucket.RepositoryPipelineVariableOptions) {
 	res, err := c.Repositories.Repository.AddPipelineVariable(v)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	opt := &bitbucket.RepositoryPipelineVariableOptions{
@@ -79,14 +79,14 @@ func testApiCalls(t *testing.T, c *bitbucket.Client, v *bitbucket.RepositoryPipe
 
 	res, err = c.Repositories.Repository.GetPipelineVariable(opt)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	assert.Equal(t, opt.Uuid, res.Uuid)
 
 	// On success the delete API doesn't return any content (HTTP status 204)
 	_, err = c.Repositories.Repository.DeletePipelineVariable(optd)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 		assert.Nilf(t, err, "expected no error returned, but got %v", err)
 	}
 }

--- a/tests/repository_test.go
+++ b/tests/repository_test.go
@@ -41,7 +41,7 @@ func TestGetRepositoryRepositories(t *testing.T) {
 
 	res, err := c.Repositories.Repository.Get(opt)
 	if err != nil {
-		t.Error("The repository is not found.")
+		t.Fatal("The repository is not found.")
 	}
 
 	if res.Full_name != owner+"/"+repo {
@@ -78,7 +78,7 @@ func TestCreateRepositoryRepositories(t *testing.T) {
 	}
 	project, err := c.Workspaces.CreateProject(projOpt)
 	if err != nil {
-		t.Error("The project could not be created.", err)
+		t.Fatal("The project could not be created.", err)
 	}
 
 	repoSlug := "go-bb-test-repo-create"
@@ -93,7 +93,7 @@ func TestCreateRepositoryRepositories(t *testing.T) {
 
 	res, err := c.Repositories.Repository.Create(repoOpt)
 	if err != nil {
-		t.Error("The project could not be created.", err)
+		t.Fatal("The project could not be created.", err)
 	}
 
 	if res.Full_name != owner+"/"+repoSlug {
@@ -146,7 +146,7 @@ func TestRepositoryUpdateForkPolicy(t *testing.T) {
 
 	res, err := c.Repositories.Repository.Get(opt)
 	if err != nil {
-		t.Error("The repository is not found.", err)
+		t.Fatal("The repository is not found.", err)
 	}
 
 	if res.Is_private != true {
@@ -162,7 +162,7 @@ func TestRepositoryUpdateForkPolicy(t *testing.T) {
 	}
 	res, err = c.Repositories.Repository.Update(opt)
 	if err != nil {
-		t.Error("The repository could not be updated.", err)
+		t.Fatal("The repository could not be updated.", err)
 	}
 
 	if res.Fork_policy != forkPolicy {
@@ -178,7 +178,7 @@ func TestRepositoryUpdateForkPolicy(t *testing.T) {
 	}
 	res, err = c.Repositories.Repository.Update(opt)
 	if err != nil {
-		t.Error("The repository could not be updated.", err)
+		t.Fatal("The repository could not be updated.", err)
 	}
 
 	if res.Fork_policy != forkPolicy {
@@ -194,7 +194,7 @@ func TestRepositoryUpdateForkPolicy(t *testing.T) {
 	}
 	res, err = c.Repositories.Repository.Update(opt)
 	if err != nil {
-		t.Error("The repository could not be updated.", err)
+		t.Fatal("The repository could not be updated.", err)
 	}
 
 	if res.Fork_policy != forkPolicy {
@@ -233,7 +233,7 @@ func TestGetRepositoryPipelineConfig(t *testing.T) {
 
 	res, err := c.Repositories.Repository.GetPipelineConfig(opt)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if res == nil {
@@ -276,7 +276,7 @@ func TestUpdateRepositoryPipelineConfig(t *testing.T) {
 
 	res, err := c.Repositories.Repository.UpdatePipelineConfig(opt)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if res == nil {
@@ -294,7 +294,7 @@ func TestUpdateRepositoryPipelineConfig(t *testing.T) {
 
 	res, err = c.Repositories.Repository.UpdatePipelineConfig(opt)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if res == nil {
@@ -337,7 +337,7 @@ func TestGetRepositoryPipelineVariables(t *testing.T) {
 
 	res, err := c.Repositories.Repository.ListPipelineVariables(opt)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if res == nil {
@@ -380,7 +380,7 @@ func TestDeleteRepositoryPipelineVariables(t *testing.T) {
 
 	res, err := c.Repositories.Repository.AddPipelineVariable(variable)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	opt := &bitbucket.RepositoryPipelineVariableDeleteOptions{
@@ -392,7 +392,7 @@ func TestDeleteRepositoryPipelineVariables(t *testing.T) {
 	// On success the delete API doesn't return any content (HTTP status 204)
 	_, err = c.Repositories.Repository.DeletePipelineVariable(opt)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 }
 
@@ -442,7 +442,7 @@ func TestGetRepositoryRefs(t *testing.T) {
 
 	branchList, err := c.Repositories.Repository.ListBranches(getOps)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	// If the branch being created already exists, delete it.
@@ -468,7 +468,7 @@ func TestGetRepositoryRefs(t *testing.T) {
 
 	resRefs, err := c.Repositories.Repository.ListRefs(refOpts)
 	if err != nil {
-		t.Error("The refs is not found.")
+		t.Fatal("The refs is not found.")
 	}
 
 	expected := struct {
@@ -537,7 +537,7 @@ func TestListRepositoryGroupPermissions(t *testing.T) {
 	res, err := c.Repositories.Repository.ListGroupPermissions(opt)
 
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if res == nil {
 		t.Error("Cannot list repository group permissions")
@@ -579,7 +579,7 @@ func TestSetRepositoryGroupPermissions(t *testing.T) {
 
 	res, err := c.Repositories.Repository.SetGroupPermissions(opt)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if res == nil {
 		t.Error("Cannot set repository group permissions")
@@ -620,7 +620,7 @@ func TestDeleteRepositoryGroupPermissions(t *testing.T) {
 
 	_, err = c.Repositories.Repository.DeleteGroupPermissions(opt)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 }
 
@@ -657,7 +657,7 @@ func TestGetRepositoryGroupPermissions(t *testing.T) {
 
 	res, err := c.Repositories.Repository.GetGroupPermissions(opt)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if res == nil {
 		t.Error("Cannot get repository group permissions")
@@ -697,7 +697,7 @@ func TestListRepositoryUserPermissions(t *testing.T) {
 	res, err := c.Repositories.Repository.ListUserPermissions(opt)
 
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if res == nil {
 		t.Error("Cannot list repository user permissions")
@@ -737,7 +737,7 @@ func TestGetRepositoryUserPermissions(t *testing.T) {
 
 	res, err := c.Repositories.Repository.GetUserPermissions(opt)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	t.Log(res)
 	if res == nil {
@@ -778,7 +778,7 @@ func TestDeleteRepositoryUserPermissions(t *testing.T) {
 
 	_, err = c.Repositories.Repository.DeleteUserPermissions(opt)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 }
 
@@ -816,7 +816,7 @@ func TestSetRepositoryUserPermissions(t *testing.T) {
 
 	res, err := c.Repositories.Repository.SetUserPermissions(opt)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if res == nil {
 		t.Error("Cannot set repository user permissions")

--- a/tests/ssh_test.go
+++ b/tests/ssh_test.go
@@ -28,7 +28,7 @@ func TestUserSSHKey(t *testing.T) {
 	}
 	userProfile, err := c.User.Profile()
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	var sshKeyResourceUuid string
@@ -43,7 +43,7 @@ func TestUserSSHKey(t *testing.T) {
 		}
 		sshUserKey, err := c.Users.SSHKeys.Create(keyOptions)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 		if sshUserKey == nil {
 			t.Error("The User SSH Key could not be created.")
@@ -57,7 +57,7 @@ func TestUserSSHKey(t *testing.T) {
 		}
 		sshKey, err := c.Users.SSHKeys.Get(keyOptions)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 		if sshKey == nil {
 			t.Error("The Deploy Key could not be retrieved.")
@@ -80,7 +80,7 @@ func TestUserSSHKey(t *testing.T) {
 		}
 		_, err := c.Users.SSHKeys.Delete(keyOptions)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 	})
 }

--- a/tests/test_setup.go
+++ b/tests/test_setup.go
@@ -21,12 +21,12 @@ var (
 func checkOwnerRepoSet(t *testing.T) error {
 	if ownerEnv == "" {
 		err := errors.New("BITBUCKET_TEST_OWNER is empty.")
-		t.Error(err)
+		t.Fatal(err)
 		return err
 	}
 	if repoEnv == "" {
 		err := errors.New("BITBUCKET_TEST_REPOSLUG is empty.")
-		t.Error(err)
+		t.Fatal(err)
 		return err
 	}
 	return nil
@@ -57,23 +57,23 @@ func setupBasicAuthTest(t *testing.T) (*bitbucket.Client, error) {
 
 	if userEnv == "" {
 		err := errors.New("BITBUCKET_TEST_USERNAME is empty.")
-		t.Error(err)
+		t.Fatal(err)
 		return nil, err
 	}
 	if passEnv == "" {
 		err := errors.New("BITBUCKET_TEST_PASSWORD is empty.")
-		t.Error(err)
+		t.Fatal(err)
 		return nil, err
 	}
 	err := checkOwnerRepoSet(t)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 		return nil, err
 	}
 
 	c, err := bitbucket.NewBasicAuth(userEnv, passEnv)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 		return nil, err
 	}
 	return c, nil
@@ -83,13 +83,13 @@ func SetupBearerToken(t *testing.T) (*bitbucket.Client, error) {
 
 	err := checkOwnerRepoSet(t)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 		return nil, err
 	}
 
 	c, err := bitbucket.NewOAuthbearerToken(accessTokenEnv)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 		return nil, err
 	}
 	return c, nil
@@ -98,19 +98,19 @@ func SetupBearerToken(t *testing.T) (*bitbucket.Client, error) {
 func SetupBearerTokenWithBaseUrlStr(t *testing.T, baseUrlStr string) (*bitbucket.Client, error) {
 	err := checkAccessTokenSet(t)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 		return nil, err
 	}
 
 	baseUrlStr, err = checkBaseUrlStrSet(t, baseUrlStr)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 		return nil, err
 	}
 
 	c, err := bitbucket.NewOAuthbearerTokenWithBaseUrlStr(accessTokenEnv, baseUrlStr)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 		return nil, err
 	}
 	return c, nil
@@ -119,13 +119,13 @@ func SetupBearerTokenWithBaseUrlStr(t *testing.T, baseUrlStr string) (*bitbucket
 func SetupBearerTokenWithBaseUrlStrCaCert(t *testing.T, baseUrlStr string, caCerts []byte) (*bitbucket.Client, error) {
 	err := checkAccessTokenSet(t)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 		return nil, err
 	}
 
 	baseUrlStr, err = checkBaseUrlStrSet(t, baseUrlStr)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 		return nil, err
 	}
 
@@ -150,7 +150,7 @@ func SetupBearerTokenWithBaseUrlStrCaCert(t *testing.T, baseUrlStr string, caCer
 
 	c, err := bitbucket.NewOAuthbearerTokenWithBaseUrlStrCaCert(accessTokenEnv, baseUrlStr, caCerts)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 		return nil, err
 	}
 	return c, nil

--- a/tests/variable_test.go
+++ b/tests/variable_test.go
@@ -44,7 +44,7 @@ func TestEndToEndDeploymentVariables(t *testing.T) {
 	expectedEnvName := "Test"
 	environments, err := c.Repositories.Repository.ListEnvironments(environmentOpt)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if found, _ := findEnvironmentByName(expectedEnvName, environments); found == nil {
@@ -58,17 +58,17 @@ func TestEndToEndDeploymentVariables(t *testing.T) {
 
 		_, err := c.Repositories.Repository.AddEnvironment(envOptAdd)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 		environments, err = c.Repositories.Repository.ListEnvironments(environmentOpt)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 	}
 
 	environment, err := findEnvironmentByName(expectedEnvName, environments)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	opt := &bitbucket.RepositoryDeploymentVariableOptions{
@@ -81,7 +81,7 @@ func TestEndToEndDeploymentVariables(t *testing.T) {
 
 	variable, err := c.Repositories.Repository.AddDeploymentVariable(opt)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	opt.Key = "bar"
@@ -90,7 +90,7 @@ func TestEndToEndDeploymentVariables(t *testing.T) {
 
 	updatedVariable, err := c.Repositories.Repository.UpdateDeploymentVariable(opt)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	listOpt := &bitbucket.RepositoryDeploymentVariablesOptions{
@@ -104,7 +104,7 @@ func TestEndToEndDeploymentVariables(t *testing.T) {
 
 	err = waitForVariables(updatedVariable.Uuid, "bar", "other value", c, listOpt)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	deleteOpt := &bitbucket.RepositoryDeploymentVariableDeleteOptions{
@@ -116,7 +116,7 @@ func TestEndToEndDeploymentVariables(t *testing.T) {
 
 	_, err = c.Repositories.Repository.DeleteDeploymentVariable(deleteOpt)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	err = waitForDeletion(updatedVariable.Uuid, c, listOpt)

--- a/tests/webhooks_test.go
+++ b/tests/webhooks_test.go
@@ -48,7 +48,7 @@ func TestWebhook(t *testing.T) {
 
 		webhook, err := c.Repositories.Webhooks.Create(opt)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 
 		if webhook == nil {
@@ -82,7 +82,7 @@ func TestWebhook(t *testing.T) {
 		}
 		webhook, err := c.Repositories.Webhooks.Get(opt)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 
 		if webhook == nil {
@@ -118,7 +118,7 @@ func TestWebhook(t *testing.T) {
 		}
 		webhook, err := c.Repositories.Webhooks.Update(opt)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 
 		if webhook == nil {
@@ -150,7 +150,7 @@ func TestWebhook(t *testing.T) {
 		}
 		_, err := c.Repositories.Webhooks.Delete(opt)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 	})
 

--- a/tests/workspace_test.go
+++ b/tests/workspace_test.go
@@ -82,7 +82,7 @@ func TestGetWorkspaceRepository(t *testing.T) {
 
 	res, err := c.Workspaces.Repositories.Repository.Get(opt)
 	if err != nil {
-		t.Error("The repository is not found.")
+		t.Fatal("The repository is not found.")
 	}
 
 	if res.Full_name != workspaceName+"/"+repositoryName {
@@ -96,7 +96,7 @@ func TestGetWorkspacePermissionForUser(t *testing.T) {
 
 	user, err := c.User.Profile()
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	res, err := c.Workspaces.Permissions.GetUserPermissionsByUuid(workspaceName, user.Uuid)


### PR DESCRIPTION
## Summary
- The branch-restrictions request body the client sent did not match the official Bitbucket Cloud OpenAPI schema (verified against `https://bitbucket.org/api/swagger.json` via Prism). Specifically: response-only `links` / `id` were leaking out, empty `users` / `groups` serialized as `null` instead of `[]`, and the schema-required `type` discriminator and `branch_match_kind` were missing. Prism's mock returned 422 for every call.
- Update `branchRestrictionsBody`: drop `links` / `id` from the wire shape, initialize `users` / `groups` to `[]`, set `type:"branchrestriction"`, default `branch_match_kind:"glob"`, and `omitempty` on `value` so `push`-style restrictions do not send an unused numeric value.
- Extend `BranchRestrictionsOptions` with `BranchMatchKind` / `BranchType` so callers can opt into the `branching_model` match path. Empty `BranchMatchKind` keeps the previous behaviour.
- Tests under `tests/` are e2e-style: many call an API method, log `t.Error(err)`, and then dereference the now-nil result, which crashed the run before the rest of the suite could report. Convert the post-call checks that fall through to a deref into `t.Fatal`. No behaviour change for green runs; failed calls now stop the test cleanly instead of panicking.

## Test plan
- [x] `go vet ./...`
- [x] `make test/unit-short` (new branchrestrictions body assertions exercise the schema-required fields)
- [x] `make test/mock`
- [x] `make test/swagger` against `docker run --rm -p 4010:4010 stoplight/prism:3 mock -h 0.0.0.0 https://bitbucket.org/api/swagger.json`: panic-free. `TestBranchRestrictionsKindPush` flips from 422→201. Remaining failures are static-mock vs e2e-expectation mismatches (e.g. Prism returns the first enum value for `kind`, list endpoints return one item), out of scope here and tracked under #361 section C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)