### PR TITLE
docs(CLAUDE.md): require unit+mock+swagger to pass before merge or release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,26 @@ docker info >/dev/null 2>&1 || open -a OrbStack
 
 Re-run the `docker run` command once OrbStack reports a healthy daemon.
 
+## Release policy
+
+Before merging any PR and before cutting a release with
+`gh release create ... --generate-notes`, the full test set above
+(unit + mock + swagger) must pass locally on the head commit. Do not
+rely on a green CI alone — `make test/ci` skips swagger contract
+coverage. Concretely:
+
+1. Check out the branch (or `master` for a release tag) at the exact
+   commit being merged or tagged.
+2. Run unit, mock, and swagger as documented above. Start the Prism
+   container first; do not skip swagger because Prism is not running.
+3. Only after all three are green: `gh pr merge --squash` (per PR) or
+   `gh release create vX.Y.Z --generate-notes`.
+
+If a swagger run surfaces a regression that is in scope of the PR or
+release, fix it before merging or tagging. Pre-existing swagger
+failures unrelated to the change should be called out in the PR
+description, not silently shipped.
+
 ## Output language
 
 Follow `~/.claude/CLAUDE.md`: chat replies in Japanese, code/identifiers in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,13 +28,16 @@ make test/swagger
 ```
 
 If `docker run` does not come up (connection refused, daemon errors), verify
-that OrbStack is running before retrying:
+that the Docker daemon (this repo's primary maintainer runs Rancher Desktop)
+is up before retrying:
 
 ```sh
-docker info >/dev/null 2>&1 || open -a OrbStack
+docker info >/dev/null 2>&1 || open -a "Rancher Desktop"
 ```
 
-Re-run the `docker run` command once OrbStack reports a healthy daemon.
+Re-run the `docker run` command once `docker info` reports a healthy daemon.
+The same step works for Docker Desktop or OrbStack — substitute the app name
+in the `open -a` invocation.
 
 ## Release policy
 


### PR DESCRIPTION
## Summary
- `CLAUDE.md` Release policy section: full test set (unit, mock, swagger via Prism in Docker) must pass locally on the head commit before any PR merge and before any `gh release create ... --generate-notes`. CI alone is not a substitute (`make test/ci` skips the swagger contract layer).
- `CLAUDE.md` swagger troubleshooting: the maintainer now runs Rancher Desktop, so the `docker info` recovery hint references `open -a "Rancher Desktop"` (Docker Desktop / OrbStack work the same way, swap the app name).
- Pre-existing swagger failures unrelated to a change must be called out in the PR description, not silently shipped.

Background: v0.9.99 was released without a local swagger run on the merged `master` head. Future patches should not skip that step.

## Test plan (head: `eb4b126`)
- [x] `make test/unit-short` — PASS
- [x] `make test/mock` — PASS
- [x] `make test/swagger` against `docker run --rm -p 4010:4010 stoplight/prism:3 mock -h 0.0.0.0 https://bitbucket.org/api/swagger.json` — panic-free; pre-existing failures only (Prism static mocks vs. e2e expectations, e.g. `kind` always returned as the first enum value, list endpoints return one item, response uuid `"string"` mismatches non-empty assertions). None are introduced by this docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)