### PR TITLE
feat: v0.10.0 — raw content commits, delete tag, status code, FilePath

### DIFF
--- a/bitbucket.go
+++ b/bitbucket.go
@@ -233,6 +233,31 @@ func (ro *RepositoryBlobWriteOptions) WithContext(ctx context.Context) *Reposito
 	return ro
 }
 
+// RepositoryContentWriteOptions describes a commit that writes one or more
+// files to a repository using the URL-encoded form variant of the source
+// endpoint. Unlike RepositoryBlobWriteOptions, contents are passed inline so
+// no temporary file on disk is required.
+//
+// See: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-source/#api-repositories-workspace-repo-slug-src-post
+type RepositoryContentWriteOptions struct {
+	Owner    string `json:"owner"`
+	RepoSlug string `json:"repo_slug"`
+	// Files maps the destination path inside the repository to the raw file
+	// content to upload.
+	Files map[string]string `json:"files"`
+	// FilesToDelete lists repo paths to remove in the same commit.
+	FilesToDelete []string `json:"files_to_delete"`
+	Author        string   `json:"author"`
+	Message       string   `json:"message"`
+	Branch        string   `json:"branch"`
+	ctx           context.Context
+}
+
+func (ro *RepositoryContentWriteOptions) WithContext(ctx context.Context) *RepositoryContentWriteOptions {
+	ro.ctx = ctx
+	return ro
+}
+
 // RepositoryRefOptions represents the options for describing a repository's refs (i.e.
 // tags and branches). The field BranchFlg is a boolean that is indicates whether a specific
 // RepositoryRefOptions instance is meant for Branch specific set of api methods.
@@ -272,6 +297,14 @@ type RepositoryBranchDeleteOptions struct {
 	RepoUUID string `json:"repo_uuid"`
 	RefName  string `json:"name"`
 	RefUUID  string `json:"ref_uuid"`
+}
+
+type RepositoryTagDeleteOptions struct {
+	Owner    string `json:"owner"`
+	RepoSlug string `json:"repo_slug"`
+	RepoUUID string `json:"repo_uuid"`
+	TagName  string `json:"name"`
+	TagUUID  string `json:"tag_uuid"`
 }
 
 type RepositoryBranchTarget struct {

--- a/client.go
+++ b/client.go
@@ -453,6 +453,23 @@ func (c *Client) executePaginated(method string, urlStr string, text string, pag
 	return result, nil
 }
 
+// executeFormURLEncoded posts an application/x-www-form-urlencoded body and
+// discards the response. It's intended for endpoints (notably the source
+// commit endpoint) that accept either multipart or URL-encoded payloads.
+func (c *Client) executeFormURLEncoded(method, urlStr string, form url.Values, ctx context.Context) error {
+	req, err := http.NewRequest(method, urlStr, strings.NewReader(form.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if ctx != nil {
+		req.WithContext(ctx)
+	}
+	c.authenticateRequest(req)
+	_, err = c.doRequest(req, true)
+	return err
+}
+
 func (c *Client) executeFileUpload(method string, urlStr string, files []File, filesToDelete []string, params map[string]string, ctx context.Context) (interface{}, error) {
 	// Prepare a form that you will submit to that URL.
 	var b bytes.Buffer
@@ -618,7 +635,10 @@ func (c *Client) doRawRequest(req *http.Request, emptyResponse bool) (io.ReadClo
 	if unexpectedHttpStatusCode(resp.StatusCode) {
 		defer resp.Body.Close()
 
-		out := &UnexpectedResponseStatusError{Status: resp.Status}
+		out := &UnexpectedResponseStatusError{
+			Status:     resp.Status,
+			StatusCode: resp.StatusCode,
+		}
 
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -190,6 +190,7 @@ func TestExecute_ErrorResponse(t *testing.T) {
 	assert.Error(t, err)
 	var unexpectedErr *UnexpectedResponseStatusError
 	assert.ErrorAs(t, err, &unexpectedErr)
+	assert.Equal(t, http.StatusNotFound, unexpectedErr.StatusCode)
 }
 
 func TestExecute_NoContentResponse(t *testing.T) {

--- a/error.go
+++ b/error.go
@@ -26,8 +26,9 @@ func DecodeError(e map[string]interface{}) error {
 // returned from the API, along with the body, if it could be read. If the body
 // could not be read, the body contains the error message trying to read it.
 type UnexpectedResponseStatusError struct {
-	Status string
-	Body   []byte
+	Status     string
+	StatusCode int
+	Body       []byte
 }
 
 func (e *UnexpectedResponseStatusError) Error() string {

--- a/error_test.go
+++ b/error_test.go
@@ -78,18 +78,21 @@ func TestDecodeError_WithFields(t *testing.T) {
 func TestUnexpectedResponseStatusError_Error(t *testing.T) {
 	t.Parallel()
 	err := &UnexpectedResponseStatusError{
-		Status: "404 Not Found",
-		Body:   []byte(`{"error": "not found"}`),
+		Status:     "404 Not Found",
+		StatusCode: 404,
+		Body:       []byte(`{"error": "not found"}`),
 	}
 
 	assert.Equal(t, "404 Not Found", err.Error())
+	assert.Equal(t, 404, err.StatusCode)
 }
 
 func TestUnexpectedResponseStatusError_ErrorWithBody(t *testing.T) {
 	t.Parallel()
 	err := &UnexpectedResponseStatusError{
-		Status: "500 Internal Server Error",
-		Body:   []byte(`{"error": "something broke"}`),
+		Status:     "500 Internal Server Error",
+		StatusCode: 500,
+		Body:       []byte(`{"error": "something broke"}`),
 	}
 
 	result := err.ErrorWithBody()

--- a/repositories.go
+++ b/repositories.go
@@ -34,8 +34,7 @@ func (r *Repositories) ListForAccount(ro *RepositoriesOptions) (*RepositoriesRes
 	if ro.Owner == "" {
 		return nil, fmt.Errorf("owner / workspace name not passed in")
 	}
-	urlPath := "/repositories/%s"
-	urlStr := r.c.requestUrl(urlPath, ro.Owner)
+	urlStr := r.c.requestUrl("/repositories/%s", ro.Owner)
 	urlAsUrl, err := url.Parse(urlStr)
 	if err != nil {
 		return nil, err

--- a/repository.go
+++ b/repository.go
@@ -337,9 +337,7 @@ func (r *Repository) Get(ro *RepositoryOptions) (*Repository, error) {
 }
 
 func (r *Repository) buildContentsURL(ro *RepositoryFilesOptions) (string, error) {
-	urlPath := "/repositories/%s/%s/src/%s/%s"
-
-	urlStr := r.c.requestUrl(urlPath, ro.Owner, ro.RepoSlug, ro.Ref, ro.Path)
+	urlStr := r.c.requestUrl("/repositories/%s/%s/src/%s/%s", ro.Owner, ro.RepoSlug, ro.Ref, ro.Path)
 	parsedUrl, err := url.Parse(urlStr)
 	if err != nil {
 		return "", err
@@ -382,8 +380,7 @@ func (r *Repository) ListFiles(ro *RepositoryFilesOptions) ([]RepositoryFile, er
 }
 
 func (r *Repository) GetFileBlob(ro *RepositoryBlobOptions) (*RepositoryBlob, error) {
-	urlPath := "/repositories/%s/%s/src/%s/%s"
-	urlStr := r.c.requestUrl(urlPath, ro.Owner, ro.RepoSlug, ro.Ref, ro.Path)
+	urlStr := r.c.requestUrl("/repositories/%s/%s/src/%s/%s", ro.Owner, ro.RepoSlug, ro.Ref, ro.Path)
 	response, err := r.c.executeRaw("GET", urlStr, "")
 	if err != nil {
 		return nil, err
@@ -418,9 +415,16 @@ func (r *Repository) WriteFileBlob(ro *RepositoryBlobWriteOptions) error {
 		if len(ro.Files) > 0 {
 			return fmt.Errorf("can't specify both files and filename")
 		}
+		// FilePath, when set, is the destination path inside the repository.
+		// FileName is the local file to read content from. When FilePath is
+		// empty, the file is uploaded at the repo root using its local name.
+		repoPath := ro.FilePath
+		if repoPath == "" {
+			repoPath = ro.FileName
+		}
 		ro.Files = []File{{
 			Path: ro.FileName,
-			Name: ro.FileName,
+			Name: repoPath,
 		}}
 	}
 
@@ -428,6 +432,40 @@ func (r *Repository) WriteFileBlob(ro *RepositoryBlobWriteOptions) error {
 
 	_, err := r.c.executeFileUpload("POST", urlStr, ro.Files, ro.FilesToDelete, m, ro.ctx)
 	return err
+}
+
+// WriteFileContent commits one or more files using their raw in-memory
+// content. This avoids the temporary-file dance required by WriteFileBlob and
+// uses the URL-encoded form variant of the source endpoint.
+//
+// See: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-source/#api-repositories-workspace-repo-slug-src-post
+func (r *Repository) WriteFileContent(ro *RepositoryContentWriteOptions) error {
+	if len(ro.Files) == 0 && len(ro.FilesToDelete) == 0 {
+		return fmt.Errorf("at least one file or files_to_delete must be specified")
+	}
+
+	form := url.Values{}
+	for path, content := range ro.Files {
+		if path == "" {
+			return fmt.Errorf("file path must not be empty")
+		}
+		form.Set(path, content)
+	}
+	for _, p := range ro.FilesToDelete {
+		form.Add("files", p)
+	}
+	if ro.Author != "" {
+		form.Set("author", ro.Author)
+	}
+	if ro.Message != "" {
+		form.Set("message", ro.Message)
+	}
+	if ro.Branch != "" {
+		form.Set("branch", ro.Branch)
+	}
+
+	urlStr := r.c.requestUrl("/repositories/%s/%s/src", ro.Owner, ro.RepoSlug)
+	return r.c.executeFormURLEncoded("POST", urlStr, form, ro.ctx)
 }
 
 // ListRefs gets all refs in the Bitbucket repository and returns them as a RepositoryRefs.
@@ -592,6 +630,21 @@ func (r *Repository) ListTags(rbo *RepositoryTagOptions) (*RepositoryTags, error
 		return nil, err
 	}
 	return decodeRepositoryTags(response)
+}
+
+// DeleteTag https://developer.atlassian.com/cloud/bitbucket/rest/api-group-refs/#api-repositories-workspace-repo-slug-refs-tags-name-delete
+func (r *Repository) DeleteTag(rbo *RepositoryTagDeleteOptions) error {
+	repo := rbo.RepoSlug
+	if rbo.RepoUUID != "" {
+		repo = rbo.RepoUUID
+	}
+	tag := rbo.TagName
+	if rbo.TagUUID != "" {
+		tag = rbo.TagUUID
+	}
+	urlStr := r.c.requestUrl("/repositories/%s/%s/refs/tags/%s", rbo.Owner, repo, tag)
+	_, err := r.c.execute("DELETE", urlStr, "")
+	return err
 }
 
 func (r *Repository) CreateTag(rbo *RepositoryTagCreationOptions) (*RepositoryTag, error) {

--- a/repository_test.go
+++ b/repository_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"testing"
 
@@ -545,6 +546,48 @@ func TestCreateTag_Success(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "v2.0", tag.Name)
 	assert.Equal(t, "v2.0", receivedBody["name"])
+}
+
+func TestDeleteTag_Success(t *testing.T) {
+	t.Parallel()
+	var receivedMethod, receivedPath string
+
+	client, server := setupMockServer(func(w http.ResponseWriter, r *http.Request) {
+		receivedMethod = r.Method
+		receivedPath = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	})
+	defer server.Close()
+
+	opts := &RepositoryTagDeleteOptions{Owner: "owner", RepoSlug: "repo", TagName: "v1.0"}
+	err := client.Repositories.Repository.DeleteTag(opts)
+
+	require.NoError(t, err)
+	assert.Equal(t, "DELETE", receivedMethod)
+	assert.Equal(t, "/2.0/repositories/owner/repo/refs/tags/v1.0", receivedPath)
+}
+
+func TestDeleteTag_WithUUIDs(t *testing.T) {
+	t.Parallel()
+	var receivedPath string
+
+	client, server := setupMockServer(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	})
+	defer server.Close()
+
+	opts := &RepositoryTagDeleteOptions{
+		Owner:    "owner",
+		RepoSlug: "repo",
+		RepoUUID: "{repo-uuid}",
+		TagName:  "v1.0",
+		TagUUID:  "{tag-uuid}",
+	}
+	err := client.Repositories.Repository.DeleteTag(opts)
+
+	require.NoError(t, err)
+	assert.Equal(t, "/2.0/repositories/owner/{repo-uuid}/refs/tags/{tag-uuid}", receivedPath)
 }
 
 // --- Refs ---
@@ -2207,6 +2250,132 @@ func TestWriteFileBlob_FileNotFound(t *testing.T) {
 	err := client.Repositories.Repository.WriteFileBlob(opts)
 
 	assert.Error(t, err)
+}
+
+func TestWriteFileBlob_FilePathUsedAsRepoDestination(t *testing.T) {
+	t.Parallel()
+	var receivedBody []byte
+
+	client, server := setupMockServer(func(w http.ResponseWriter, r *http.Request) {
+		buf, _ := io.ReadAll(r.Body)
+		receivedBody = buf
+		w.WriteHeader(http.StatusCreated)
+	})
+	defer server.Close()
+
+	tmpFile, err := os.CreateTemp("", "blob-filepath-*.txt")
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+	_, err = tmpFile.WriteString("content")
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	opts := &RepositoryBlobWriteOptions{
+		Owner:    "owner",
+		RepoSlug: "repo",
+		FileName: tmpFile.Name(),
+		FilePath: "src/dest.txt",
+	}
+	err = client.Repositories.Repository.WriteFileBlob(opts)
+	require.NoError(t, err)
+
+	// The multipart form should reference the repo destination (FilePath),
+	// not the local file path.
+	assert.Contains(t, string(receivedBody), `name="src/dest.txt"`)
+	assert.NotContains(t, string(receivedBody), `name="`+tmpFile.Name()+`"`)
+}
+
+// --- WriteFileContent ---
+
+func TestWriteFileContent_Success(t *testing.T) {
+	t.Parallel()
+	var (
+		receivedMethod      string
+		receivedContentType string
+		receivedBody        []byte
+	)
+
+	client, server := setupMockServer(func(w http.ResponseWriter, r *http.Request) {
+		receivedMethod = r.Method
+		receivedContentType = r.Header.Get("Content-Type")
+		receivedBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusCreated)
+	})
+	defer server.Close()
+
+	opts := &RepositoryContentWriteOptions{
+		Owner:    "owner",
+		RepoSlug: "repo",
+		Files: map[string]string{
+			"src/main.go": "package main\n",
+		},
+		Message: "add main",
+		Author:  "Test <test@example.com>",
+		Branch:  "main",
+	}
+	err := client.Repositories.Repository.WriteFileContent(opts)
+	require.NoError(t, err)
+
+	assert.Equal(t, "POST", receivedMethod)
+	assert.Equal(t, "application/x-www-form-urlencoded", receivedContentType)
+
+	values, parseErr := url.ParseQuery(string(receivedBody))
+	require.NoError(t, parseErr)
+	assert.Equal(t, "package main\n", values.Get("src/main.go"))
+	assert.Equal(t, "add main", values.Get("message"))
+	assert.Equal(t, "Test <test@example.com>", values.Get("author"))
+	assert.Equal(t, "main", values.Get("branch"))
+}
+
+func TestWriteFileContent_Empty(t *testing.T) {
+	t.Parallel()
+	client, server := setupMockServer(func(w http.ResponseWriter, r *http.Request) {})
+	defer server.Close()
+
+	err := client.Repositories.Repository.WriteFileContent(&RepositoryContentWriteOptions{
+		Owner:    "owner",
+		RepoSlug: "repo",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one file")
+}
+
+func TestWriteFileContent_EmptyPath(t *testing.T) {
+	t.Parallel()
+	client, server := setupMockServer(func(w http.ResponseWriter, r *http.Request) {})
+	defer server.Close()
+
+	err := client.Repositories.Repository.WriteFileContent(&RepositoryContentWriteOptions{
+		Owner:    "owner",
+		RepoSlug: "repo",
+		Files:    map[string]string{"": "x"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "file path must not be empty")
+}
+
+func TestWriteFileContent_Delete(t *testing.T) {
+	t.Parallel()
+	var receivedBody []byte
+
+	client, server := setupMockServer(func(w http.ResponseWriter, r *http.Request) {
+		receivedBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusCreated)
+	})
+	defer server.Close()
+
+	opts := &RepositoryContentWriteOptions{
+		Owner:         "owner",
+		RepoSlug:      "repo",
+		FilesToDelete: []string{"old.txt"},
+		Message:       "remove old",
+	}
+	err := client.Repositories.Repository.WriteFileContent(opts)
+	require.NoError(t, err)
+
+	values, parseErr := url.ParseQuery(string(receivedBody))
+	require.NoError(t, parseErr)
+	assert.Equal(t, "old.txt", values.Get("files"))
 }
 
 // --- Error paths for Pipeline, Environment, etc. ---


### PR DESCRIPTION
## Summary

複数の open issue を一括で解決する v0.10.0 候補。後方互換は維持。

| Issue | 内容 | 主な変更箇所 |
| --- | --- | --- |
| #310 | `UnexpectedResponseStatusError` に `StatusCode int` を追加。レスポンスステータスを数値で扱える | `error.go`, `client.go` |
| #337 | `requestUrl` 呼び出しの非定数 format string を解消 (Go 1.24+ `go vet` 警告対応) | `repositories.go`, `repository.go` |
| #296 | `WriteFileBlob` が `RepositoryBlobWriteOptions.FilePath` を未参照だった件を修正。`FileName + FilePath` 併用時に FilePath をリポジトリ側の宛先パスとして使用 | `repository.go` |
| #314 | `WriteFileContent` を追加。URL-encoded form でメモリ上の内容を直接コミットでき、一時ファイル不要 | `bitbucket.go`, `client.go`, `repository.go` |
| #154 | `DeleteTag` (および `RepositoryTagDeleteOptions`) を追加。既存の `DeleteBranch` と対称 | `bitbucket.go`, `repository.go` |

## Backwards compatibility

- `UnexpectedResponseStatusError.Status` (string) は据え置き。`StatusCode int` の追加のみ。
- `WriteFileBlob` は `FileName` 単独利用時の挙動を維持。`FilePath` を併用したときのみ宛先パスが変化。
- 既存メソッドのシグネチャ変更なし。

## Test plan

- [x] `make test/unit` — green
- [x] `make test/mock` — green
- [x] `make test/swagger` — master と同数の 39 failure / 8 pass。新規退化なし
  - 失敗テスト群は #313 / #361 と同じく `BITBUCKET_TEST_*` 環境変数および E2E 認証セットアップに依存しており、Prism mock 単体では通らない既知の状態。本 PR の変更とは無関係。
- [x] `go vet ./...` — clean
- 新規ユニットテスト
  - `TestUnexpectedResponseStatusError_Error` / `_ErrorWithBody` を `StatusCode` 検証付きに更新
  - `TestExecute_ErrorResponse` に `StatusCode` 検証を追加
  - `TestWriteFileBlob_FilePathUsedAsRepoDestination`
  - `TestWriteFileContent_Success` / `_Empty` / `_EmptyPath` / `_Delete`
  - `TestDeleteTag_Success` / `_WithUUIDs`

## Closes

Closes #310
Closes #337
Closes #296
Closes #314
Closes #154

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>